### PR TITLE
feat: update Flutter version to 3.35.x in auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.24.x"
+          flutter-version: "3.35.x"
           channel: "stable"
 
       - name: Get version


### PR DESCRIPTION
This pull request updates the Flutter version used in the GitHub Actions workflow for automatic releases. The workflow now uses a newer stable version of Flutter to ensure compatibility and access to the latest features and fixes.

Dependency update:

* [`.github/workflows/auto-release.yml`](diffhunk://#diff-5a93af5afcdcd2bdc566f58652f8af7fec28b2d02acb9bec8ee97e9334362731L36-R36): Updated the `flutter-version` in the `Setup Flutter` step from `3.24.x` to `3.35.x`.