### PR TITLE
Feat/timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,16 @@
-## 0.5.0
+## Changelog
 
-**Domain Layer Refactoring and Expansion:**
+### Timeout configuration support
 
-- Consolidated exports in `lib/ciot.dart` to use `domain.dart` and `infra.dart`, simplifying and centralizing the public API surface. [[1]](diffhunk://#diff-2ffa3795e2614cb6d98eeee13af8f4c6737839adbfcf5790775e156bc6c01dabL3-R5) [[2]](diffhunk://#diff-c4dea886147b3bd255334be56d415357132275f0071403234ee3151a319f31feR1-R13) [[3]](diffhunk://#diff-6cb509fa384decae08138d5c80505c7062bcee73c8f09eaf001159023708f611R1-R7)
-- Added new domain use cases and models: `CheckFirmwareVersion`, `GetDeviceData`, `OtaStart`, and `SysReset`, along with a `SysInfoExtension` for easier firmware version access. [[1]](diffhunk://#diff-9064b2f8258254e6e2648b4e8465354018775f8853b6874b4a391135e6e14aecR1-R3) [[2]](diffhunk://#diff-7ce80b0d1ea8ea16b59bdebfe160f759eee01031609cd4e5071534167c82339aR1-R7) [[3]](diffhunk://#diff-6a5587848ffbe507e94812fe090a871d08a3e03ab0361f14d22f29e20311ff05R1-R9) [[4]](diffhunk://#diff-49408ef83f422c981f8cd897ffc48173a76ff01300e133a72a188da2fef3c0dbR1-R6) [[5]](diffhunk://#diff-a37c88c9b603340821f39c142e85a29aa7ebbe33f503924d008c7295bd143710R1-R5)
+* Added a new abstract method `setTimeout(int timeout)` to the `Iface` interface, allowing timeout values to be set for implementations.
+* Updated `IfaceBase` to accept an optional `timeout` parameter in `sendMsg` and `send` methods, invoking `setTimeout` when provided. [[1]](diffhunk://#diff-e7a2f0d9e4431e510a3a94012ef65e39e7f1d0b5189e18e426be441b7bd1370eL20-R22) [[2]](diffhunk://#diff-e7a2f0d9e4431e510a3a94012ef65e39e7f1d0b5189e18e426be441b7bd1370eL36-R42)
 
-**Infrastructure Layer Implementations:**
+### Implementation in concrete classes
 
-- Implemented infrastructure classes for the new use cases:
-  - `HgCheckFirmwareVersionImpl` for version comparison logic.
-  - `GetDeviceDataImpl` for retrieving device data generically across interface types.
-  - `OtaStartImpl` for managing OTA firmware updates, including an HTTP server to serve firmware files and stream OTA status updates.
-  - `SysResetImpl` for sending system reset commands to devices.
+* Implemented `setTimeout` in `HttpClient` to update the configuration's timeout value, and added a similar method for IP address configuration.
+* Implemented `setTimeout` in `MqttClient` to update the internal completer timeout, and used this value for response timeouts in message publishing. [[1]](diffhunk://#diff-d9c1196ce1154d78ce9e790902c967d468814ad7f275dfed7b6361cd84c85890R46-R47) [[2]](diffhunk://#diff-d9c1196ce1154d78ce9e790902c967d468814ad7f275dfed7b6361cd84c85890L169-R172) [[3]](diffhunk://#diff-d9c1196ce1154d78ce9e790902c967d468814ad7f275dfed7b6361cd84c85890R267-R272)
+* Implemented `setTimeout` in `HttpServer` to return an error, indicating that timeouts are not supported for this interface.
 
-**Improvements and Fixes:**
+### Usage of timeouts in Wifi scanning
 
-- Updated `HttpClient.getData` to use the correct type checks and return values, improving type safety and correctness.
-- Modified WiFi scan implementation to return results sorted by signal strength (RSSI), enhancing usability for consumers of the API.
-
-**Dependency Cleanup:**
-
-- Removed the unused `dartz` dependency from `pubspec.yaml`.
+* Updated `WifiScanImpl` to use the new timeout parameter when sending messages, ensuring scan operations and AP info retrieval respect a 5000ms timeout.

--- a/lib/src/domain/interfaces/iface.dart
+++ b/lib/src/domain/interfaces/iface.dart
@@ -13,4 +13,5 @@ abstract class Iface {
   Either<ErrorBase, Unit> processData(MsgData data);
   Future<Either<ErrorBase, Uint8List>> sendData(Uint8List data);
   Either<ErrorBase, MsgData> getData(MsgData data);
+  Either<ErrorBase, Unit> setTimeout(int timeout);
 }

--- a/lib/src/domain/interfaces/iface_base.dart
+++ b/lib/src/domain/interfaces/iface_base.dart
@@ -17,8 +17,9 @@ abstract class IfaceBase implements Iface {
 
   IfaceBase.withSerializer(this._serializer);
 
-  Future<Either<ErrorBase, Msg>> sendMsg(Msg msg, {bool force = false}) async {
+  Future<Either<ErrorBase, Msg>> sendMsg(Msg msg, {bool force = false, int? timeout}) async {
     if (_sending && !force) return Either.left(ErrorBusy());
+    if (timeout != null) setTimeout(timeout);
     _sending = true;
     try {
       _sentMsgId = Random().nextInt(1 << 31);
@@ -33,11 +34,12 @@ abstract class IfaceBase implements Iface {
     }
   }
 
-  Future<Either<ErrorBase, T>> send<T>(T msg, {bool force = false}) async {
+  Future<Either<ErrorBase, T>> send<T>(T msg, {bool force = false, int? timeout}) async {
     if (_sending && !force) {
       return Either.left(ErrorBusy());
     }
     _sending = true;
+    if (timeout != null) setTimeout(timeout);
     try {
       _sentMsgId = Random().nextInt(1 << 31);
       (msg as dynamic).id = _sentMsgId;

--- a/lib/src/infra/interfaces/http_client.dart
+++ b/lib/src/infra/interfaces/http_client.dart
@@ -102,6 +102,24 @@ class HttpClient extends IfaceBase {
     }
   }
 
+  @override
+  Either<ErrorBase, Unit> setTimeout(int timeout) {
+    if (_cfg == null) {
+      return Left(ErrorNullConfig());
+    }
+    _cfg!.timeout = timeout;
+    return const Right(unit);
+  }
+
+  @override
+  Either<ErrorBase, Unit> setIp(String ip) {
+    if (_cfg == null) {
+      return Left(ErrorNullConfig());
+    }
+    _cfg!.url = ip;
+    return const Right(unit);
+  }
+
   Future<Either<ErrorBase, Uint8List>> httpRequest(Uri uri, Uint8List data) async {
     if (_cfg == null) {
       return Either.left(ErrorNullConfig());

--- a/lib/src/infra/interfaces/http_client.dart
+++ b/lib/src/infra/interfaces/http_client.dart
@@ -111,7 +111,6 @@ class HttpClient extends IfaceBase {
     return const Right(unit);
   }
 
-  @override
   Either<ErrorBase, Unit> setIp(String ip) {
     if (_cfg == null) {
       return Left(ErrorNullConfig());

--- a/lib/src/infra/interfaces/http_server.dart
+++ b/lib/src/infra/interfaces/http_server.dart
@@ -110,4 +110,9 @@ class HttpServer extends IfaceBase {
       }
     });
   }
+  
+  @override
+  Either<ErrorBase, Unit> setTimeout(int timeout) {
+    return Left(ErrorNotSupported());
+  }
 }

--- a/lib/src/infra/interfaces/mqtt_client.dart
+++ b/lib/src/infra/interfaces/mqtt_client.dart
@@ -43,6 +43,8 @@ class MqttClient extends IfaceBase {
 
   final List<String> _subscribedTopics = [];
 
+  int _completerTimeout = 5000;
+
   MqttClient(int id)
       : info = IfaceInfo(
           id: id,
@@ -166,8 +168,8 @@ class MqttClient extends IfaceBase {
     final builder = mqtt.MqttClientPayloadBuilder();
     builder.addBuffer(buffer);
     _client!.publishMessage(_cfg!.topics.pub, mqtt.MqttQos.values[_cfg!.qos], builder.payload!);
-    var result =
-        await _responseCompleter!.future.timeout(const Duration(seconds: 5), onTimeout: () => Left(ErrorTimeout()));
+    var result = await _responseCompleter!.future
+        .timeout(Duration(milliseconds: _completerTimeout), onTimeout: () => Left(ErrorTimeout()));
     return result;
   }
 
@@ -261,5 +263,11 @@ class MqttClient extends IfaceBase {
 
     _subscribedTopics.clear();
     _onEventController.add(Event(type: EventType.EVENT_TYPE_STOPPED));
+  }
+
+  @override
+  Either<ErrorBase, Unit> setTimeout(int timeout) {
+    _completerTimeout = timeout;
+    return Either.right(unit);
   }
 }

--- a/lib/src/infra/usecases/wifi_scan_impl.dart
+++ b/lib/src/infra/usecases/wifi_scan_impl.dart
@@ -26,16 +26,14 @@ class WifiScanImpl implements WifiScan {
   Future<Either<ErrorBase, WifiReqScanResult>> _startScan(int ifaceId, {bool force = false}) async {
     final ifaceInfo = IfaceInfo(id: ifaceId, type: IfaceType.IFACE_TYPE_WIFI);
     final msg = Msg(iface: ifaceInfo, data: MsgData(wifi: WifiData(request: WifiReq(scan: WifiReqScan()))));
-    final result = await _iface.sendMsg(msg, force: force);
-    return result.match(
-      (l) => left(l), 
-      (r) => right(r.data.wifi.request.scanResult));
+    final result = await _iface.sendMsg(msg, force: force, timeout: 5000);
+    return result.match((l) => left(l), (r) => right(r.data.wifi.request.scanResult));
   }
 
   Future<Either<ErrorBase, WifiApInfo>> _getScannedAp(int ifaceId, int apId, {bool force = false}) async {
     final ifaceInfo = IfaceInfo(id: ifaceId, type: IfaceType.IFACE_TYPE_WIFI);
     final msg = Msg(iface: ifaceInfo, data: MsgData(wifi: WifiData(request: WifiReq(getAp: WifiReqGetAp(id: apId)))));
-    final result = await _iface.sendMsg(msg, force: force);
+    final result = await _iface.sendMsg(msg, force: force, timeout: 5000);
     return result.match((l) => left(l), (r) => right(r.data.wifi.request.apInfo));
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ciot_dart
 description: "A new Flutter package project."
-version: 0.7.0+1
+version: 0.8.0+1
 publish_to: none
 
 environment:


### PR DESCRIPTION
This pull request adds support for configurable timeouts to the interface layer and updates its implementations to handle timeouts appropriately. The changes ensure that timeouts can be set for different interface types and are respected during message sending and response handling.

### Timeout configuration support

* Added a new abstract method `setTimeout(int timeout)` to the `Iface` interface, allowing timeout values to be set for implementations.
* Updated `IfaceBase` to accept an optional `timeout` parameter in `sendMsg` and `send` methods, invoking `setTimeout` when provided. [[1]](diffhunk://#diff-e7a2f0d9e4431e510a3a94012ef65e39e7f1d0b5189e18e426be441b7bd1370eL20-R22) [[2]](diffhunk://#diff-e7a2f0d9e4431e510a3a94012ef65e39e7f1d0b5189e18e426be441b7bd1370eL36-R42)

### Implementation in concrete classes

* Implemented `setTimeout` in `HttpClient` to update the configuration's timeout value, and added a similar method for IP address configuration.
* Implemented `setTimeout` in `MqttClient` to update the internal completer timeout, and used this value for response timeouts in message publishing. [[1]](diffhunk://#diff-d9c1196ce1154d78ce9e790902c967d468814ad7f275dfed7b6361cd84c85890R46-R47) [[2]](diffhunk://#diff-d9c1196ce1154d78ce9e790902c967d468814ad7f275dfed7b6361cd84c85890L169-R172) [[3]](diffhunk://#diff-d9c1196ce1154d78ce9e790902c967d468814ad7f275dfed7b6361cd84c85890R267-R272)
* Implemented `setTimeout` in `HttpServer` to return an error, indicating that timeouts are not supported for this interface.

### Usage of timeouts in Wifi scanning

* Updated `WifiScanImpl` to use the new timeout parameter when sending messages, ensuring scan operations and AP info retrieval respect a 5000ms timeout.