### PR TITLE
test: update sendMsg calls in WifiScanImpl tests to include force and…

### DIFF
--- a/test/src/infra/usecases/wifi_scan_impl_test.dart
+++ b/test/src/infra/usecases/wifi_scan_impl_test.dart
@@ -67,7 +67,7 @@ void main() {
         );
 
         // Mock para todas as chamadas
-        when(() => mockIface.sendMsg(any())).thenAnswer((invocation) async {
+        when(() => mockIface.sendMsg(any(), force: false, timeout: 5000)).thenAnswer((invocation) async {
           final msg = invocation.positionalArguments[0] as Msg;
 
           // Se é uma requisição de scan
@@ -105,13 +105,13 @@ void main() {
         );
 
         // Verify que sendMsg foi chamado 3 vezes (1 scan + 2 getAp)
-        verify(() => mockIface.sendMsg(any())).called(3);
+        verify(() => mockIface.sendMsg(any(), force: false, timeout: 5000)).called(3);
       });
 
       test('deve retornar ErrorBase quando startScan falhar', () async {
         // Arrange
         final error = ErrorTimeout();
-        when(() => mockIface.sendMsg(any())).thenAnswer((_) async => left(error));
+        when(() => mockIface.sendMsg(any(), force: false, timeout: 5000)).thenAnswer((_) async => left(error));
 
         // Act
         final result = await wifiScanImpl.call(0);
@@ -124,7 +124,7 @@ void main() {
         );
 
         // Verify que sendMsg foi chamado apenas 1 vez
-        verify(() => mockIface.sendMsg(any())).called(1);
+        verify(() => mockIface.sendMsg(any(), force: false, timeout: 5000)).called(1);
       });
 
       test('deve retornar lista vazia quando count for 0', () async {
@@ -138,7 +138,8 @@ void main() {
           ),
         );
 
-        when(() => mockIface.sendMsg(any())).thenAnswer((_) async => right(msgResponseScan));
+        when(() => mockIface.sendMsg(any(), force: false, timeout: 5000))
+            .thenAnswer((_) async => right(msgResponseScan));
 
         // Act
         final result = await wifiScanImpl.call(0);
@@ -151,7 +152,7 @@ void main() {
         );
 
         // Verify que sendMsg foi chamado apenas 1 vez (só o scan)
-        verify(() => mockIface.sendMsg(any())).called(1);
+        verify(() => mockIface.sendMsg(any(), force: false, timeout: 5000)).called(1);
       });
 
       test('deve continuar mesmo se getScannedAp falhar para algum AP', () async {
@@ -179,7 +180,7 @@ void main() {
         );
 
         // Mock para todas as chamadas
-        when(() => mockIface.sendMsg(any())).thenAnswer((invocation) async {
+        when(() => mockIface.sendMsg(any(), force: false, timeout: 5000)).thenAnswer((invocation) async {
           final msg = invocation.positionalArguments[0] as Msg;
 
           // Se é uma requisição de scan
@@ -214,7 +215,7 @@ void main() {
         );
 
         // Verify que sendMsg foi chamado 3 vezes
-        verify(() => mockIface.sendMsg(any())).called(3);
+        verify(() => mockIface.sendMsg(any(), force: false, timeout: 5000)).called(3);
       });
 
       test('deve enviar mensagem correta para startScan', () async {
@@ -229,7 +230,7 @@ void main() {
         );
 
         Msg? capturedMsg;
-        when(() => mockIface.sendMsg(any())).thenAnswer((invocation) async {
+        when(() => mockIface.sendMsg(any(), force: false, timeout: 5000)).thenAnswer((invocation) async {
           capturedMsg = invocation.positionalArguments[0] as Msg;
           return right(msgResponseScan);
         });
@@ -240,7 +241,7 @@ void main() {
         // Assert
         expect(capturedMsg, isNotNull);
         expect(capturedMsg!.data.wifi.request.hasScan(), true);
-        verify(() => mockIface.sendMsg(any())).called(1);
+        verify(() => mockIface.sendMsg(any(), force: false, timeout: 5000)).called(1);
       });
 
       test('deve enviar mensagem correta para getScannedAp com id correto', () async {
@@ -264,7 +265,7 @@ void main() {
         );
 
         final capturedMsgs = <Msg>[];
-        when(() => mockIface.sendMsg(any())).thenAnswer((invocation) async {
+        when(() => mockIface.sendMsg(any(), force: false, timeout: 5000)).thenAnswer((invocation) async {
           final msg = invocation.positionalArguments[0] as Msg;
           capturedMsgs.add(msg);
 


### PR DESCRIPTION
This pull request updates the tests in `wifi_scan_impl_test.dart` to ensure that all calls to the mocked `sendMsg` method include the `force: false` and `timeout: 5000` parameters. This change makes the tests more accurate by matching the actual method signature used in production code.

**Test consistency improvements:**

* Updated all `when` and `verify` calls for `mockIface.sendMsg` to include the `force: false` and `timeout: 5000` parameters, ensuring mocks and verifications match the expected method signature. [[1]](diffhunk://#diff-f8bff419cc81899095f0c0b062b3067cad00662ab9546ae11db5cedea9fe9ca8L70-R70) [[2]](diffhunk://#diff-f8bff419cc81899095f0c0b062b3067cad00662ab9546ae11db5cedea9fe9ca8L108-R114) [[3]](diffhunk://#diff-f8bff419cc81899095f0c0b062b3067cad00662ab9546ae11db5cedea9fe9ca8L127-R127) [[4]](diffhunk://#diff-f8bff419cc81899095f0c0b062b3067cad00662ab9546ae11db5cedea9fe9ca8L141-R142) [[5]](diffhunk://#diff-f8bff419cc81899095f0c0b062b3067cad00662ab9546ae11db5cedea9fe9ca8L154-R155) [[6]](diffhunk://#diff-f8bff419cc81899095f0c0b062b3067cad00662ab9546ae11db5cedea9fe9ca8L182-R183) [[7]](diffhunk://#diff-f8bff419cc81899095f0c0b062b3067cad00662ab9546ae11db5cedea9fe9ca8L217-R218) [[8]](diffhunk://#diff-f8bff419cc81899095f0c0b062b3067cad00662ab9546ae11db5cedea9fe9ca8L232-R233) [[9]](diffhunk://#diff-f8bff419cc81899095f0c0b062b3067cad00662ab9546ae11db5cedea9fe9ca8L243-R244) [[10]](diffhunk://#diff-f8bff419cc81899095f0c0b062b3067cad00662ab9546ae11db5cedea9fe9ca8L267-R268)… timeout parameters