### PR TITLE
Feat/timeout

### DIFF
--- a/lib/src/domain/usecases/wifi_scan.dart
+++ b/lib/src/domain/usecases/wifi_scan.dart
@@ -3,5 +3,5 @@ import 'package:ciot_dart/generated/ciot/proto/v2/wifi.pb.dart';
 import 'package:fpdart/fpdart.dart';
 
 abstract class WifiScan {
-  Future<Either<ErrorBase, List<WifiApInfo>>> call(int ifaceId, {bool force = false});
+  Future<Either<ErrorBase, List<WifiApInfo>>> call(int ifaceId, {bool force = false, int timeout = 8000});
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ciot_dart
 description: "A new Flutter package project."
-version: 0.8.0+2
+version: 0.8.0+3
 publish_to: none
 
 environment:


### PR DESCRIPTION
This pull request introduces a minor update to the package version and extends the `WifiScan` use case interface to support a timeout parameter. These changes improve API flexibility and version tracking.

Versioning:

* Updated the package version in `pubspec.yaml` from `0.8.0+2` to `0.8.0+3` to reflect the new changes.

API enhancement:

* Modified the `WifiScan` abstract class in `lib/src/domain/usecases/wifi_scan.dart` to add a `timeout` parameter (defaulting to 8000ms) to the `call` method, allowing for more control over Wi-Fi scan operations.