### PR TITLE
Feat/timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Added a new abstract method `setTimeout(int timeout)` to the `Iface` interface, allowing timeout values to be set for implementations.
 * Updated `IfaceBase` to accept an optional `timeout` parameter in `sendMsg` and `send` methods, invoking `setTimeout` when provided. [[1]](diffhunk://#diff-e7a2f0d9e4431e510a3a94012ef65e39e7f1d0b5189e18e426be441b7bd1370eL20-R22) [[2]](diffhunk://#diff-e7a2f0d9e4431e510a3a94012ef65e39e7f1d0b5189e18e426be441b7bd1370eL36-R42)
 
+* Enhanced the `send` method in `IfaceBase` to wait for completion when a send is already in progress, with proper timeout checks to avoid indefinite blocking. If the timeout is exceeded while waiting, an `ErrorTimeout` is returned.
+* Adjusted timeout setting logic to account for elapsed time during waiting, ensuring accurate timeout enforcement when sending messages.
+
 ### Implementation in concrete classes
 
 * Implemented `setTimeout` in `HttpClient` to update the configuration's timeout value, and added a similar method for IP address configuration.
@@ -14,3 +17,7 @@
 ### Usage of timeouts in Wifi scanning
 
 * Updated `WifiScanImpl` to use the new timeout parameter when sending messages, ensuring scan operations and AP info retrieval respect a 5000ms timeout.
+
+### Breaking changes
+
+* `force` parameter on `send` operations is not supported anymore. Now sending messages always wait for the last sent completion. Adjust the timeout to avoid errors on concurrence cases.

--- a/lib/src/domain/interfaces/iface_base.dart
+++ b/lib/src/domain/interfaces/iface_base.dart
@@ -1,6 +1,5 @@
 import 'dart:math' as math;
 import 'dart:typed_data';
-import 'dart:developer';
 
 import 'package:ciot_dart/generated/ciot/proto/v2/msg.pb.dart';
 import 'package:ciot_dart/src/domain/interfaces/iface.dart';
@@ -19,27 +18,17 @@ abstract class IfaceBase implements Iface {
   IfaceBase.withSerializer(this._serializer);
 
   Future<Either<ErrorBase, Msg>> sendMsg(Msg msg, {bool force = false, int? timeout}) async {
-    if (_sending && !force) return Either.left(ErrorBusy());
-    if (timeout != null) setTimeout(timeout);
-    _sending = true;
-    try {
-      _sentMsgId = math.Random().nextInt(1 << 31);
-      msg.id = _sentMsgId;
-      var result = await sendData(_serializer.serialize(msg));
-      return result.match(
-        (l) => Either.left(l),
-        (r) => Either.right(_serializer.deserialize<Msg>(r)),
-      );
-    } finally {
-      _sending = false;
-    }
+    var result = await send(_serializer.serialize(msg));
+    return result.match(
+      (l) => Either.left(l),
+      (r) => Either.right(_serializer.deserialize<Msg>(r)),
+    );
   }
 
   Future<Either<ErrorBase, T>> send<T>(T msg, {bool force = false, int? timeout}) async {
     final startedAt = DateTime.now();
 
     if (_sending && !force) {
-      log('Already sending a message, waiting for it to finish before sending the next one...');
       while (_sending) {
         if (timeout != null) {
           final elapsed = DateTime.now().difference(startedAt).inMilliseconds;

--- a/lib/src/domain/interfaces/iface_base.dart
+++ b/lib/src/domain/interfaces/iface_base.dart
@@ -1,5 +1,6 @@
-import 'dart:math';
+import 'dart:math' as math;
 import 'dart:typed_data';
+import 'dart:developer';
 
 import 'package:ciot_dart/generated/ciot/proto/v2/msg.pb.dart';
 import 'package:ciot_dart/src/domain/interfaces/iface.dart';
@@ -22,7 +23,7 @@ abstract class IfaceBase implements Iface {
     if (timeout != null) setTimeout(timeout);
     _sending = true;
     try {
-      _sentMsgId = Random().nextInt(1 << 31);
+      _sentMsgId = math.Random().nextInt(1 << 31);
       msg.id = _sentMsgId;
       var result = await sendData(_serializer.serialize(msg));
       return result.match(
@@ -35,13 +36,39 @@ abstract class IfaceBase implements Iface {
   }
 
   Future<Either<ErrorBase, T>> send<T>(T msg, {bool force = false, int? timeout}) async {
+    final startedAt = DateTime.now();
+
     if (_sending && !force) {
-      return Either.left(ErrorBusy());
+      log('Already sending a message, waiting for it to finish before sending the next one...');
+      while (_sending) {
+        if (timeout != null) {
+          final elapsed = DateTime.now().difference(startedAt).inMilliseconds;
+          if (elapsed >= timeout) {
+            return Either.left(ErrorTimeout());
+          }
+          final remaining = timeout - elapsed;
+          final delayMs = remaining < 10 ? remaining : 10;
+          await Future.delayed(Duration(milliseconds: delayMs));
+        } else {
+          await Future.delayed(const Duration(milliseconds: 10));
+        }
+      }
     }
+
     _sending = true;
-    if (timeout != null) setTimeout(timeout);
+
+    if (timeout != null) {
+      final elapsed = DateTime.now().difference(startedAt).inMilliseconds;
+      final remaining = timeout - elapsed;
+      if (remaining <= 0) {
+        _sending = false;
+        return Either.left(ErrorTimeout());
+      }
+      setTimeout(remaining);
+    }
+
     try {
-      _sentMsgId = Random().nextInt(1 << 31);
+      _sentMsgId = math.Random().nextInt(1 << 31);
       (msg as dynamic).id = _sentMsgId;
       var result = await sendData(_serializer.serialize(msg));
       return result.match(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ciot_dart
 description: "A new Flutter package project."
-version: 0.8.0+3
+version: 0.8.0+4
 publish_to: none
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ciot_dart
 description: "A new Flutter package project."
-version: 0.8.0+4
+version: 1.0.0+5
 publish_to: none
 
 environment:


### PR DESCRIPTION
This pull request introduces significant improvements to timeout handling and concurrency management in the `IfaceBase` interface, along with breaking changes to the message sending API. The changes ensure that send operations wait for completion with accurate timeout enforcement and remove the previously supported `force` parameter. The package version is also updated to reflect these breaking changes.

### Timeout and concurrency improvements

* Enhanced the `send` method in `IfaceBase` to wait for completion when a send is already in progress, with proper timeout checks to avoid indefinite blocking. If the timeout is exceeded while waiting, an `ErrorTimeout` is returned. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R10) [[2]](diffhunk://#diff-e7a2f0d9e4431e510a3a94012ef65e39e7f1d0b5189e18e426be441b7bd1370eL21-R60)
* Adjusted timeout setting logic to account for elapsed time during waiting, ensuring accurate timeout enforcement when sending messages. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R10) [[2]](diffhunk://#diff-e7a2f0d9e4431e510a3a94012ef65e39e7f1d0b5189e18e426be441b7bd1370eL21-R60)

### Breaking API changes

* Removed support for the `force` parameter on `send` operations. Sending messages now always waits for the last sent completion; users should adjust the timeout to avoid errors in concurrent cases.

### Miscellaneous

* Changed the import of `Random` to use the `math` namespace for clarity in `iface_base.dart`.
* Updated the package version in `pubspec.yaml` to `1.0.0+5` to reflect the breaking changes.