### PR TITLE
Feat/timeout

### DIFF
--- a/lib/src/domain/interfaces/iface_base.dart
+++ b/lib/src/domain/interfaces/iface_base.dart
@@ -17,18 +17,18 @@ abstract class IfaceBase implements Iface {
 
   IfaceBase.withSerializer(this._serializer);
 
-  Future<Either<ErrorBase, Msg>> sendMsg(Msg msg, {bool force = false, int? timeout}) async {
-    var result = await send(_serializer.serialize(msg));
+  Future<Either<ErrorBase, Msg>> sendMsg(Msg msg, {int? timeout}) async {
+    var result = await send(msg);
     return result.match(
       (l) => Either.left(l),
-      (r) => Either.right(_serializer.deserialize<Msg>(r)),
+      (r) => Either.right(r),
     );
   }
 
-  Future<Either<ErrorBase, T>> send<T>(T msg, {bool force = false, int? timeout}) async {
+  Future<Either<ErrorBase, T>> send<T>(T msg, {int? timeout}) async {
     final startedAt = DateTime.now();
 
-    if (_sending && !force) {
+    if (_sending) {
       while (_sending) {
         if (timeout != null) {
           final elapsed = DateTime.now().difference(startedAt).inMilliseconds;

--- a/lib/src/domain/usecases/delete_iface_cfg.dart
+++ b/lib/src/domain/usecases/delete_iface_cfg.dart
@@ -3,5 +3,5 @@ import 'package:ciot_dart/generated/ciot/proto/v2/iface.pb.dart';
 import 'package:fpdart/fpdart.dart';
 
 abstract class DeleteIfaceCfg {
-  Future<Either<ErrorBase, void>> call(int ciotId, IfaceInfo iface);
+  Future<Either<ErrorBase, void>> call(int ciotId, IfaceInfo iface, {int? timeout});
 }

--- a/lib/src/domain/usecases/get_device_data.dart
+++ b/lib/src/domain/usecases/get_device_data.dart
@@ -3,5 +3,5 @@ import 'package:ciot_dart/generated/ciot/proto/v2/iface.pbenum.dart';
 import 'package:fpdart/fpdart.dart';
 
 abstract class GetDeviceData {
-  Future<Either<ErrorBase, T>> call<T>(int ifaceId, IfaceType ifaceType, DataType dataType, {bool force = false});
+  Future<Either<ErrorBase, T>> call<T>(int ifaceId, IfaceType ifaceType, DataType dataType, {int? timeout});
 }

--- a/lib/src/domain/usecases/mqtt_client_start.dart
+++ b/lib/src/domain/usecases/mqtt_client_start.dart
@@ -3,5 +3,5 @@ import 'package:ciot_dart/generated/ciot/proto/v2/mqtt_client.pb.dart';
 import 'package:fpdart/fpdart.dart';
 
 abstract class MqttClientStart {
-  Future<Either<ErrorBase, MqttClientStatus>> call(int ifaceId, MqttClientCfg cfg, {bool force = false});
+  Future<Either<ErrorBase, MqttClientStatus>> call(int ifaceId, MqttClientCfg cfg, {int? timeout});
 }

--- a/lib/src/domain/usecases/ntp_start.dart
+++ b/lib/src/domain/usecases/ntp_start.dart
@@ -3,5 +3,5 @@ import 'package:ciot_dart/generated/ciot/proto/v2/ntp.pb.dart';
 import 'package:fpdart/fpdart.dart';
 
 abstract class NtpStart {
-  Future<Either<ErrorBase, NtpStatus>> call(int ifaceId, NtpCfg cfg);
+  Future<Either<ErrorBase, NtpStatus>> call(int ifaceId, NtpCfg cfg, {int? timeout});
 }

--- a/lib/src/domain/usecases/ota_start.dart
+++ b/lib/src/domain/usecases/ota_start.dart
@@ -5,5 +5,5 @@ import 'package:fpdart/fpdart.dart';
 abstract class OtaStart {
   Stream<Either<ErrorBase, OtaStatus>> get statusStream;
   Future<String> serverUrl(String deviceIP);
-  Future<Either<ErrorBase, OtaStatus>> call(OtaCfg req, {bool force = false});
+  Future<Either<ErrorBase, OtaStatus>> call(OtaCfg req, {int? timeout});
 }

--- a/lib/src/domain/usecases/save_iface_cfg.dart
+++ b/lib/src/domain/usecases/save_iface_cfg.dart
@@ -3,5 +3,5 @@ import 'package:ciot_dart/generated/ciot/proto/v2/iface.pb.dart';
 import 'package:fpdart/fpdart.dart';
 
 abstract class SaveIfaceCfg {
-  Future<Either<ErrorBase, void>> call(int ciotId, IfaceInfo iface);
+  Future<Either<ErrorBase, void>> call(int ciotId, IfaceInfo iface, {int? timeout});
 }

--- a/lib/src/domain/usecases/sys_reset.dart
+++ b/lib/src/domain/usecases/sys_reset.dart
@@ -2,5 +2,5 @@ import 'package:ciot_dart/ciot.dart';
 import 'package:fpdart/fpdart.dart';
 
 abstract class SysReset {
-  Future<Either<ErrorBase, void>> call(int sysIfaceId, {bool force = false});
+  Future<Either<ErrorBase, void>> call(int sysIfaceId, {int? timeout});
 }

--- a/lib/src/domain/usecases/wifi_scan.dart
+++ b/lib/src/domain/usecases/wifi_scan.dart
@@ -3,5 +3,5 @@ import 'package:ciot_dart/generated/ciot/proto/v2/wifi.pb.dart';
 import 'package:fpdart/fpdart.dart';
 
 abstract class WifiScan {
-  Future<Either<ErrorBase, List<WifiApInfo>>> call(int ifaceId, {bool force = false, int timeout = 8000});
+  Future<Either<ErrorBase, List<WifiApInfo>>> call(int ifaceId, {int timeout = 8000});
 }

--- a/lib/src/domain/usecases/wifi_start.dart
+++ b/lib/src/domain/usecases/wifi_start.dart
@@ -3,5 +3,5 @@ import 'package:ciot_dart/src/errors/errors.dart';
 import 'package:fpdart/fpdart.dart';
 
 abstract class WifiStart {
-  Future<Either<ErrorBase, WifiStatus>> call(int ifaceId, WifiCfg cfg, {bool force = false});
+  Future<Either<ErrorBase, WifiStatus>> call(int ifaceId, WifiCfg cfg, {int? timeout});
 }

--- a/lib/src/infra/usecases/delete_iface_cfg_impl.dart
+++ b/lib/src/infra/usecases/delete_iface_cfg_impl.dart
@@ -3,7 +3,6 @@ import 'package:ciot_dart/generated/ciot/proto/v2/ciot.pb.dart';
 import 'package:ciot_dart/generated/ciot/proto/v2/iface.pb.dart';
 import 'package:ciot_dart/generated/ciot/proto/v2/msg.pb.dart';
 import 'package:ciot_dart/generated/ciot/proto/v2/msg_data.pb.dart';
-import 'package:ciot_dart/src/domain/usecases/delete_iface_cfg.dart';
 import 'package:fpdart/fpdart.dart';
 
 class DeleteIfaceCfgImpl implements DeleteIfaceCfg {
@@ -12,12 +11,12 @@ class DeleteIfaceCfgImpl implements DeleteIfaceCfg {
   DeleteIfaceCfgImpl(this.ifaceBase);
 
   @override
-  Future<Either<ErrorBase, void>> call(int ciotId, IfaceInfo iface) async {
+  Future<Either<ErrorBase, void>> call(int ciotId, IfaceInfo iface, {int? timeout}) async {
     var msg = Msg(
       iface: IfaceInfo(id: ciotId, type: IfaceType.IFACE_TYPE_CIOT),
       data: MsgData(ciot: Data(request: Req(deleteCfg: iface))),
     );
-    var resul = await ifaceBase.send(msg);
+    var resul = await ifaceBase.send(msg, timeout: timeout);
     return resul.match((l) => left(l), (r) => right(null));
   }
 }

--- a/lib/src/infra/usecases/get_device_data_impl.dart
+++ b/lib/src/infra/usecases/get_device_data_impl.dart
@@ -10,7 +10,7 @@ class GetDeviceDataImpl implements GetDeviceData {
   GetDeviceDataImpl(this.iface);
 
   @override
-  Future<Either<ErrorBase, T>> call<T>(int ifaceId, IfaceType ifaceType, DataType dataType, {bool force = false}) async {
+  Future<Either<ErrorBase, T>> call<T>(int ifaceId, IfaceType ifaceType, DataType dataType, {int? timeout}) async {
     var msg = Msg(
       iface: IfaceInfo(
         id: ifaceId,
@@ -22,7 +22,7 @@ class GetDeviceDataImpl implements GetDeviceData {
         ),
       ),
     );
-    var result = await iface.send(msg, force: force);
+    var result = await iface.send(msg, timeout: timeout);
     return result.match(
       (l) => left((l)),
       (r) {

--- a/lib/src/infra/usecases/mqtt_client_start_impl.dart
+++ b/lib/src/infra/usecases/mqtt_client_start_impl.dart
@@ -11,11 +11,11 @@ class MqttClientStartImpl implements MqttClientStart {
   MqttClientStartImpl(this.iface);
 
   @override
-  Future<Either<ErrorBase, MqttClientStatus>> call(int ifaceId, MqttClientCfg cfg, {bool force = false}) async {
+  Future<Either<ErrorBase, MqttClientStatus>> call(int ifaceId, MqttClientCfg cfg, {int? timeout}) async {
     final msg = Msg(
         iface: IfaceInfo(id: ifaceId, type: IfaceType.IFACE_TYPE_MQTT_CLIENT),
         data: MsgData(mqttClient: MqttClientData(config: cfg)));
-    final result = await iface.send(msg, force: force);
+    final result = await iface.send(msg, timeout: timeout);
     return result.match(
       (l) => Left(l),
       (r) => Right(r.data.mqttClient.status),

--- a/lib/src/infra/usecases/ntp_start_impl.dart
+++ b/lib/src/infra/usecases/ntp_start_impl.dart
@@ -3,7 +3,6 @@ import 'package:ciot_dart/generated/ciot/proto/v2/iface.pb.dart';
 import 'package:ciot_dart/generated/ciot/proto/v2/msg.pb.dart';
 import 'package:ciot_dart/generated/ciot/proto/v2/msg_data.pb.dart';
 import 'package:ciot_dart/generated/ciot/proto/v2/ntp.pb.dart';
-import 'package:ciot_dart/src/domain/usecases/ntp_start.dart';
 import 'package:fpdart/src/either.dart';
 
 class NtpStartImpl implements NtpStart {
@@ -12,14 +11,14 @@ class NtpStartImpl implements NtpStart {
   NtpStartImpl(this.iface);
 
   @override
-  Future<Either<ErrorBase, NtpStatus>> call(int ifaceId, NtpCfg cfg) async {
+  Future<Either<ErrorBase, NtpStatus>> call(int ifaceId, NtpCfg cfg, {int? timeout}) async {
     final msg = Msg(
         iface: IfaceInfo(
           id: ifaceId,
           type: IfaceType.IFACE_TYPE_NTP,
         ),
         data: MsgData(ntp: NtpData(config: cfg)));
-    final result = await iface.sendMsg(msg);
+    final result = await iface.sendMsg(msg, timeout: timeout);
     return result.match(
       (l) => Left(l),
       (r) => Right(r.data.ntp.status),

--- a/lib/src/infra/usecases/ota_start_impl.dart
+++ b/lib/src/infra/usecases/ota_start_impl.dart
@@ -43,7 +43,7 @@ class OtaStartImpl implements OtaStart {
   }
 
   @override
-  Future<Either<ErrorBase, OtaStatus>> call(OtaCfg req, {bool force = false}) async {
+  Future<Either<ErrorBase, OtaStatus>> call(OtaCfg req, {int? timeout}) async {
     if (cfg.serverCfg != null) {
       await _startServer(cfg.serverCfg!);
     }
@@ -54,7 +54,7 @@ class OtaStartImpl implements OtaStart {
               config: req),
         ));
     log('OTA request url: ${msg.data.ota.config.url}');
-    var result = await iface.send(msg, force: force);
+    var result = await iface.send(msg, timeout: timeout);
     return result.match(
       (l) => Left(l), 
       (r) => Right(r.data.ota.status));

--- a/lib/src/infra/usecases/save_iface_cfg_impl.dart
+++ b/lib/src/infra/usecases/save_iface_cfg_impl.dart
@@ -11,12 +11,12 @@ class SaveIfaceCfgImpl implements SaveIfaceCfg {
   SaveIfaceCfgImpl(this.ifaceBase);
 
   @override
-  Future<Either<ErrorBase, void>> call(int ciotId, IfaceInfo iface) async {
+  Future<Either<ErrorBase, void>> call(int ciotId, IfaceInfo iface, {int? timeout}) async {
     var msg = Msg(
       iface: IfaceInfo(id: ciotId, type: IfaceType.IFACE_TYPE_CIOT),
       data: MsgData(ciot: Data(request: Req(saveCfg: iface))),
     );
-    var resul = await ifaceBase.send(msg);
+    var resul = await ifaceBase.send(msg, timeout: timeout);
     return resul.match((l) => left(l), (r) => right(null));
   }
 }

--- a/lib/src/infra/usecases/sys_reset_impl.dart
+++ b/lib/src/infra/usecases/sys_reset_impl.dart
@@ -11,7 +11,7 @@ class SysResetImpl implements SysReset {
   SysResetImpl(this.iface);
 
   @override
-  Future<Either<ErrorBase, void>> call(int sysIfaceId, {bool force = false}) async {
+  Future<Either<ErrorBase, void>> call(int sysIfaceId, {int? timeout}) async {
     var msg = Msg(
       iface: IfaceInfo(
         id: sysIfaceId,
@@ -23,6 +23,6 @@ class SysResetImpl implements SysReset {
           )
         )
       ));
-    return iface.sendMsg(msg);
+    return iface.sendMsg(msg, timeout: timeout);
   }
 }

--- a/lib/src/infra/usecases/wifi_scan_impl.dart
+++ b/lib/src/infra/usecases/wifi_scan_impl.dart
@@ -11,29 +11,29 @@ class WifiScanImpl implements WifiScan {
   WifiScanImpl(this._iface);
 
   @override
-  Future<Either<ErrorBase, List<WifiApInfo>>> call(int ifaceId, {bool force = false, int timeout = 8000}) async {
-    var startScan = await _startScan(ifaceId, force: force, timeout: timeout);
+  Future<Either<ErrorBase, List<WifiApInfo>>> call(int ifaceId, {int timeout = 8000}) async {
+    var startScan = await _startScan(ifaceId, timeout: timeout);
     return startScan.match((l) => left(l), (r) async {
       var apInfos = <WifiApInfo>[];
       for (var i = 0; i < r.count; i++) {
-        var getScannerAp = await _getScannedAp(ifaceId, i, force: force, timeout: timeout);
+        var getScannerAp = await _getScannedAp(ifaceId, i, timeout: timeout);
         getScannerAp.match((l) => null, (r) => apInfos.add(r));
       }
       return right(apInfos..sort((a, b) => b.rssi.compareTo(a.rssi)));
     });
   }
 
-  Future<Either<ErrorBase, WifiReqScanResult>> _startScan(int ifaceId, {bool force = false, required int timeout}) async {
+  Future<Either<ErrorBase, WifiReqScanResult>> _startScan(int ifaceId, {required int timeout}) async {
     final ifaceInfo = IfaceInfo(id: ifaceId, type: IfaceType.IFACE_TYPE_WIFI);
     final msg = Msg(iface: ifaceInfo, data: MsgData(wifi: WifiData(request: WifiReq(scan: WifiReqScan()))));
-    final result = await _iface.sendMsg(msg, force: force, timeout: timeout);
+    final result = await _iface.sendMsg(msg, timeout: timeout);
     return result.match((l) => left(l), (r) => right(r.data.wifi.request.scanResult));
   }
 
-  Future<Either<ErrorBase, WifiApInfo>> _getScannedAp(int ifaceId, int apId, {bool force = false, required int timeout}) async {
+  Future<Either<ErrorBase, WifiApInfo>> _getScannedAp(int ifaceId, int apId, {required int timeout}) async {
     final ifaceInfo = IfaceInfo(id: ifaceId, type: IfaceType.IFACE_TYPE_WIFI);
     final msg = Msg(iface: ifaceInfo, data: MsgData(wifi: WifiData(request: WifiReq(getAp: WifiReqGetAp(id: apId)))));
-    final result = await _iface.sendMsg(msg, force: force, timeout: timeout);
+    final result = await _iface.sendMsg(msg, timeout: timeout);
     return result.match((l) => left(l), (r) => right(r.data.wifi.request.apInfo));
   }
 }

--- a/lib/src/infra/usecases/wifi_start_impl.dart
+++ b/lib/src/infra/usecases/wifi_start_impl.dart
@@ -12,7 +12,7 @@ class WifiStartImpl implements WifiStart {
   WifiStartImpl(this.iface);
 
   @override
-  Future<Either<ErrorBase, WifiStatus>> call(int ifaceId, WifiCfg cfg, {bool force = false}) async {
+  Future<Either<ErrorBase, WifiStatus>> call(int ifaceId, WifiCfg cfg, {int? timeout}) async {
     final msg = Msg(
       iface: IfaceInfo(
         id: ifaceId,
@@ -24,7 +24,7 @@ class WifiStartImpl implements WifiStart {
         )
       )
     );
-    final result = await iface.send(msg, force: force);
+    final result = await iface.send(msg, timeout: timeout);
     return result.match(
       (l) => Left(l),
       (r) => Right(r.data.wifi.status),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ciot_dart
 description: "A new Flutter package project."
-version: 1.0.0+5
+version: 1.0.0+6
 publish_to: none
 
 environment:

--- a/test/src/infra/usecases/wifi_scan_impl_test.dart
+++ b/test/src/infra/usecases/wifi_scan_impl_test.dart
@@ -67,7 +67,7 @@ void main() {
         );
 
         // Mock para todas as chamadas
-        when(() => mockIface.sendMsg(any(), force: false, timeout: 8000)).thenAnswer((invocation) async {
+        when(() => mockIface.sendMsg(any(), timeout: 8000)).thenAnswer((invocation) async {
           final msg = invocation.positionalArguments[0] as Msg;
 
           // Se é uma requisição de scan
@@ -105,13 +105,13 @@ void main() {
         );
 
         // Verify que sendMsg foi chamado 3 vezes (1 scan + 2 getAp)
-        verify(() => mockIface.sendMsg(any(), force: false, timeout: 8000)).called(3);
+        verify(() => mockIface.sendMsg(any(), timeout: 8000)).called(3);
       });
 
       test('deve retornar ErrorBase quando startScan falhar', () async {
         // Arrange
         final error = ErrorTimeout();
-        when(() => mockIface.sendMsg(any(), force: false, timeout: 8000)).thenAnswer((_) async => left(error));
+        when(() => mockIface.sendMsg(any(), timeout: 8000)).thenAnswer((_) async => left(error));
 
         // Act
         final result = await wifiScanImpl.call(0);
@@ -124,7 +124,7 @@ void main() {
         );
 
         // Verify que sendMsg foi chamado apenas 1 vez
-        verify(() => mockIface.sendMsg(any(), force: false, timeout: 8000)).called(1);
+        verify(() => mockIface.sendMsg(any(), timeout: 8000)).called(1);
       });
 
       test('deve retornar lista vazia quando count for 0', () async {
@@ -138,7 +138,7 @@ void main() {
           ),
         );
 
-        when(() => mockIface.sendMsg(any(), force: false, timeout: 8000))
+        when(() => mockIface.sendMsg(any(), timeout: 8000))
             .thenAnswer((_) async => right(msgResponseScan));
 
         // Act
@@ -152,7 +152,7 @@ void main() {
         );
 
         // Verify que sendMsg foi chamado apenas 1 vez (só o scan)
-        verify(() => mockIface.sendMsg(any(), force: false, timeout: 8000)).called(1);
+        verify(() => mockIface.sendMsg(any(), timeout: 8000)).called(1);
       });
 
       test('deve continuar mesmo se getScannedAp falhar para algum AP', () async {
@@ -180,7 +180,7 @@ void main() {
         );
 
         // Mock para todas as chamadas
-        when(() => mockIface.sendMsg(any(), force: false, timeout: 8000)).thenAnswer((invocation) async {
+        when(() => mockIface.sendMsg(any(), timeout: 8000)).thenAnswer((invocation) async {
           final msg = invocation.positionalArguments[0] as Msg;
 
           // Se é uma requisição de scan
@@ -215,7 +215,7 @@ void main() {
         );
 
         // Verify que sendMsg foi chamado 3 vezes
-        verify(() => mockIface.sendMsg(any(), force: false, timeout: 8000)).called(3);
+        verify(() => mockIface.sendMsg(any(), timeout: 8000)).called(3);
       });
 
       test('deve enviar mensagem correta para startScan', () async {
@@ -230,7 +230,7 @@ void main() {
         );
 
         Msg? capturedMsg;
-        when(() => mockIface.sendMsg(any(), force: false, timeout: 8000)).thenAnswer((invocation) async {
+        when(() => mockIface.sendMsg(any(), timeout: 8000)).thenAnswer((invocation) async {
           capturedMsg = invocation.positionalArguments[0] as Msg;
           return right(msgResponseScan);
         });
@@ -241,7 +241,7 @@ void main() {
         // Assert
         expect(capturedMsg, isNotNull);
         expect(capturedMsg!.data.wifi.request.hasScan(), true);
-        verify(() => mockIface.sendMsg(any(), force: false, timeout: 8000)).called(1);
+        verify(() => mockIface.sendMsg(any(), timeout: 8000)).called(1);
       });
 
       test('deve enviar mensagem correta para getScannedAp com id correto', () async {
@@ -265,7 +265,7 @@ void main() {
         );
 
         final capturedMsgs = <Msg>[];
-        when(() => mockIface.sendMsg(any(), force: false, timeout: 8000)).thenAnswer((invocation) async {
+        when(() => mockIface.sendMsg(any(), timeout: 8000)).thenAnswer((invocation) async {
           final msg = invocation.positionalArguments[0] as Msg;
           capturedMsgs.add(msg);
 


### PR DESCRIPTION
This pull request refactors the interface and implementation of several use cases in the codebase to improve consistency and flexibility. The main change is replacing the `force` parameter with an optional `timeout` parameter in the method signatures, allowing for better control over request timing. Additionally, all affected implementations have been updated to use the new `timeout` parameter, and the package version has been incremented.

**API parameter refactoring:**

* Replaced the `force` parameter with an optional `timeout` parameter in the method signatures of all use case interfaces, such as `DeleteIfaceCfg`, `GetDeviceData`, `MqttClientStart`, `NtpStart`, `OtaStart`, `SaveIfaceCfg`, `SysReset`, `WifiScan`, and `WifiStart`. This change enables more granular control of request timeouts and improves API consistency. [[1]](diffhunk://#diff-1d7af9214addf14900ef12159ea9f297845495b3572d79088a89b87f2f47ded0L6-R6) [[2]](diffhunk://#diff-7ce80b0d1ea8ea16b59bdebfe160f759eee01031609cd4e5071534167c82339aL6-R6) [[3]](diffhunk://#diff-4bb307d4c010b56a587761db707580c90da6026c7db5d8571d58588c9fdb39a3L6-R6) [[4]](diffhunk://#diff-084900fb9cf3f0d00278afcf5fa2a87e7823d6074e3036b3f8a0932601ae5c05L6-R6) [[5]](diffhunk://#diff-6a5587848ffbe507e94812fe090a871d08a3e03ab0361f14d22f29e20311ff05L8-R8) [[6]](diffhunk://#diff-000020b2455a5cc6f60a7d3961f445ba19ee357fd7ba425f9f1f9ac85b902c8aL6-R6) [[7]](diffhunk://#diff-49408ef83f422c981f8cd897ffc48173a76ff01300e133a72a188da2fef3c0dbL5-R5) [[8]](diffhunk://#diff-39b1e810614699cf17a8bdacce1ee47c48e70cd4ee7ad2915f7d20778afd6d71L6-R6) [[9]](diffhunk://#diff-449e361d01b6ea555f97c2000f7db2f0d7f0a6c011c1addb33298567d479d22eL6-R6)

* Updated all corresponding use case implementations to propagate the new `timeout` parameter and remove the `force` parameter, ensuring that requests are handled according to the new API contract. [[1]](diffhunk://#diff-4384dcbdcca63f597ae85b8ebe44515994be86e8f0678ae4c5d744fb13406ba9L15-R19) [[2]](diffhunk://#diff-5ebb9270c4933729ed33c51b81b0da9e5c062e5ce1d6a8c471eaa94bba7a6043L13-R13) [[3]](diffhunk://#diff-5ebb9270c4933729ed33c51b81b0da9e5c062e5ce1d6a8c471eaa94bba7a6043L25-R25) [[4]](diffhunk://#diff-0f116b93c869e9939ab97791bb2c11471ebcc5c5b04077a21037f7be04b927b7L14-R18) [[5]](diffhunk://#diff-0ef80b1fd329c879701e7f13f53b40c9dabde8d465289f1489303295939a4eedL15-R21) [[6]](diffhunk://#diff-4d90f1e2664e03525f2e20ce9013c93ebe63b4d390f439e5433687f23ad532d1L46-R46) [[7]](diffhunk://#diff-4d90f1e2664e03525f2e20ce9013c93ebe63b4d390f439e5433687f23ad532d1L57-R57) [[8]](diffhunk://#diff-42c1642957438952099ea8d200ac7f8b63c0ffe76745cb24074905ce77aa54f1L14-R19) [[9]](diffhunk://#diff-6137819ebc0fab91cb4241ea229ebf4d41c6f35934440621343795209ddf8adbL14-R14) [[10]](diffhunk://#diff-6137819ebc0fab91cb4241ea229ebf4d41c6f35934440621343795209ddf8adbL26-R26) [[11]](diffhunk://#diff-064c229f871ce3c3fb30485ce98648fcb14b0e7af914eb46cbed84cdafb1e109L14-R36) [[12]](diffhunk://#diff-9068c32502eee09778a4406fff56cd94960cec2c52a56ac5eeceb512c5551180L15-R15) [[13]](diffhunk://#diff-9068c32502eee09778a4406fff56cd94960cec2c52a56ac5eeceb512c5551180L27-R27)

**Core interface update:**

* Modified the `IfaceBase` class to remove the `force` parameter from `sendMsg` and `send` methods, and to accept the new `timeout` parameter, aligning the core interface with the updated use case APIs.

**Versioning:**

* Incremented the package version in `pubspec.yaml` from `1.0.0+5` to `1.0.0+6` to reflect the breaking API changes.

**Cleanup:**

* Removed redundant imports from use case implementation files, cleaning up the codebase. [[1]](diffhunk://#diff-4384dcbdcca63f597ae85b8ebe44515994be86e8f0678ae4c5d744fb13406ba9L6) [[2]](diffhunk://#diff-0ef80b1fd329c879701e7f13f53b40c9dabde8d465289f1489303295939a4eedL6)

These changes collectively improve the consistency, flexibility, and maintainability of the codebase.