### PR TITLE
Feat/timeout

### DIFF
--- a/lib/src/domain/domain.dart
+++ b/lib/src/domain/domain.dart
@@ -14,4 +14,5 @@ export 'usecases/save_iface_cfg.dart';
 export 'usecases/sys_reset.dart';
 export 'usecases/wifi_scan.dart';
 export 'usecases/wifi_start.dart';
+export 'usecases/wifi_stop.dart';
 export 'usecases/delete_iface_cfg.dart';

--- a/lib/src/domain/interfaces/iface_base.dart
+++ b/lib/src/domain/interfaces/iface_base.dart
@@ -18,7 +18,7 @@ abstract class IfaceBase implements Iface {
   IfaceBase.withSerializer(this._serializer);
 
   Future<Either<ErrorBase, Msg>> sendMsg(Msg msg, {int? timeout}) async {
-    var result = await send(msg);
+    var result = await send(msg, timeout: timeout);
     return result.match(
       (l) => Either.left(l),
       (r) => Either.right(r),

--- a/lib/src/domain/usecases/wifi_stop.dart
+++ b/lib/src/domain/usecases/wifi_stop.dart
@@ -1,0 +1,6 @@
+import 'package:ciot_dart/ciot.dart';
+import 'package:fpdart/fpdart.dart';
+
+abstract class WifiStop {
+  Future<Either<ErrorBase, void>> call(int ifaceId);
+}

--- a/lib/src/infra/infra.dart
+++ b/lib/src/infra/infra.dart
@@ -11,4 +11,5 @@ export 'usecases/save_iface_cfg_impl.dart';
 export 'usecases/sys_reset_impl.dart';
 export 'usecases/wifi_scan_impl.dart';
 export 'usecases/wifi_start_impl.dart';
+export 'usecases/wifi_stop_impl.dart';
 export 'usecases/delete_iface_cfg_impl.dart';

--- a/lib/src/infra/usecases/wifi_start_impl.dart
+++ b/lib/src/infra/usecases/wifi_start_impl.dart
@@ -28,6 +28,6 @@ class WifiStartImpl implements WifiStart {
     return result.match(
       (l) => Left(l),
       (r) => Right(r.data.wifi.status),
-    );    
+    );
   }
 }

--- a/lib/src/infra/usecases/wifi_stop_impl.dart
+++ b/lib/src/infra/usecases/wifi_stop_impl.dart
@@ -1,0 +1,33 @@
+import 'package:fpdart/fpdart.dart';
+
+import '../../../ciot.dart';
+import '../../../generated/ciot/proto/v2/iface.pb.dart';
+import '../../../generated/ciot/proto/v2/msg.pb.dart';
+import '../../../generated/ciot/proto/v2/msg_data.pb.dart';
+import '../../../generated/ciot/proto/v2/wifi.pb.dart' as pb;
+
+class WifiStopImpl implements WifiStop {
+  final IfaceBase iface;
+
+  WifiStopImpl(this.iface);
+
+  @override
+  Future<Either<ErrorBase, pb.WifiStatus>> call(int ifaceId, {int? timeout}) async {
+    final msg = Msg(
+      iface: IfaceInfo(
+        id: ifaceId,
+        type: IfaceType.IFACE_TYPE_WIFI
+      ),
+      data: MsgData(
+        wifi: pb.WifiData(
+          stop: pb.WifiStop(),
+        )
+      )
+    );
+    final result = await iface.send(msg, timeout: timeout);
+    return result.match(
+      (l) => Left(l),
+      (r) => Right(r.data.wifi.status),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ciot_dart
 description: "A new Flutter package project."
-version: 1.0.0+6
+version: 1.0.0+7
 publish_to: none
 
 environment:


### PR DESCRIPTION
This pull request adds support for stopping Wi-Fi interfaces to the project, including the definition of the `WifiStop` use case and its implementation. Additionally, it makes a small improvement to the `IfaceBase` interface to allow passing a timeout when sending messages. The package version is also incremented to reflect these changes.

**Wi-Fi Stop Use Case Integration:**

* Added the abstract `WifiStop` use case in `wifi_stop.dart` and exported it from the domain layer. [[1]](diffhunk://#diff-be7c6235bcb152e443401a60ad95dff2c79bed526f167113187049a70452d434R1-R6) [[2]](diffhunk://#diff-c4dea886147b3bd255334be56d415357132275f0071403234ee3151a319f31feR17)
* Implemented the `WifiStopImpl` class in `wifi_stop_impl.dart` to handle stopping a Wi-Fi interface, including message construction and result handling, and exported it from the infra layer. [[1]](diffhunk://#diff-ddb486c45fcbeed49748aeeb5b9c3060552ca2c95ed8bca7ceda0c1840438e59R1-R33) [[2]](diffhunk://#diff-6cb509fa384decae08138d5c80505c7062bcee73c8f09eaf001159023708f611R14)

**Interface Improvements:**

* Updated `IfaceBase.sendMsg` to pass the optional `timeout` parameter to the underlying `send` method, improving timeout handling for interface operations.

**Project Metadata:**

* Bumped the package version to `1.0.0+7` in `pubspec.yaml`.