### PR TITLE
Feat/validators

### DIFF
--- a/lib/src/domain/domain.dart
+++ b/lib/src/domain/domain.dart
@@ -18,3 +18,4 @@ export 'usecases/wifi_multi_start.dart';
 export 'usecases/wifi_scan.dart';
 export 'usecases/wifi_start.dart';
 export 'usecases/wifi_stop.dart';
+export 'validators/validators.dart';

--- a/lib/src/domain/validators/VALIDATORS_README.md
+++ b/lib/src/domain/validators/VALIDATORS_README.md
@@ -1,0 +1,449 @@
+# Sistema de Validações - CIOT Dart
+
+## Visão Geral
+
+O sistema de validações fornece ferramentas simples e reutilizáveis para validar entradas comuns em aplicações IoT, como:
+- **Endereços IP** (IPv4, IPv6, máscaras de rede)
+- **URLs** (HTTP, HTTPS, esquemas customizados)
+- **Emails** (validação de domínio)
+- **Senhas** (com requisitos configuráveis)
+
+## Arquitetura
+
+O sistema é dividido em **duas camadas complementares**:
+
+### 1. Validators Simples
+Funções estáticas rápidas, sem injeção de dependência. Ideais para:
+- Validações diretas e isoladas
+- Sem necessidade de estado ou mocking em testes
+- Máximo desempenho
+
+**Localização**: `lib/src/domain/validators/`
+
+**Exemplos**:
+```dart
+// IP Validator
+final ipResult = IpValidator.validate('192.168.1.1');
+final ipv4Result = IpValidator.validateIpv4('192.168.1.1');
+final maskResult = IpValidator.validateSubnetMask('255.255.255.0');
+
+// Email Validator
+final emailResult = EmailValidator.validate('user@example.com');
+
+// URL Validator
+final urlResult = UrlValidator.validateHttpUrl('https://example.com');
+
+// Password Validator
+final pwdResult = PasswordValidator.validate('MyPassword123');
+```
+
+### 2. Validation Usecases (Futuro)
+Para validações complexas que encapsulam múltiplos validators. Implementadas com:
+- Injeção de dependência
+- Histórico de validações
+- Integração com eventos/BLoC
+
+**Localização**: `lib/src/domain/usecases/validations/`
+
+*Será implementado na próxima fase conforme necessário*
+
+---
+
+## Tipos de Dados
+
+### `ValidationError` - Enum
+Representa todos os tipos possíveis de erros de validação:
+
+```dart
+enum ValidationError {
+  invalidIp,              // IP inválido
+  invalidUrl,             // URL inválida
+  invalidEmail,           // Email inválido
+  invalidPassword,        // Senha fraca/inválida
+  emptyValue,             // Valor vazio
+  invalidSubnetMask,      // Máscara de rede inválida
+  invalidGateway,         // Gateway inválido
+  invalidSsid,            // SSID WiFi inválido
+  invalidPort,            // Porta inválida
+  invalidLength,          // Comprimento fora do intervalo
+  invalidCharacters,      // Caracteres não permitidos
+  generic,                // Erro genérico
+}
+```
+
+### `ValidationResult<T>` - Type Alias
+Resultado de validação usando Either monad:
+
+```dart
+typedef ValidationResult<T> = Either<ValidationError, T>;
+
+// Uso:
+ValidationResult<String> result = IpValidator.validate('192.168.1.1');
+
+result.fold(
+  (error) => print('Erro: ${error.description}'),     // Left - erro
+  (value) => print('Válido: $value'),                 // Right - sucesso
+);
+```
+
+### Extensão `ValidationResultX<T>`
+Métodos auxiliares para trabalhar com resultados:
+
+```dart
+final result = IpValidator.validate('192.168.1.1');
+
+result.isValid;     // bool - se passou na validação
+result.isInvalid;   // bool - se falhou na validação
+result.value;       // T? - valor se passou, null se falhou
+result.error;       // ValidationError? - erro se falhou
+```
+
+---
+
+## Validators Disponíveis
+
+### IP Validator
+
+```dart
+class IpValidator {
+  // Valida IPv4, IPv6, ou qualquer IP
+  static ValidationResult<IpValidationResult> validate(String value)
+  
+  // Valida apenas IPv4
+  static ValidationResult<String> validateIpv4(String value)
+  
+  // Valida apenas IPv6
+  static ValidationResult<String> validateIpv6(String value)
+  
+  // Valida máscara de rede (CIDR ou dotted decimal)
+  static ValidationResult<String> validateSubnetMask(String value)
+}
+```
+
+**Exemplos**:
+```dart
+// IPv4 válido
+IpValidator.validate('192.168.0.1')        // ✓ isValid
+IpValidator.validateIpv4('192.168.0.1')    // ✓
+
+// IPv6 válido
+IpValidator.validate('2001:db8::1')        // ✓ isValid
+IpValidator.validateIpv6('2001:db8::1')    // ✓
+
+// Máscara de rede
+IpValidator.validateSubnetMask('255.255.255.0')  // ✓
+IpValidator.validateSubnetMask('/24')             // ✓
+
+// Inválido
+IpValidator.validate('256.168.1.1')        // ✗ invalidIp
+IpValidator.validateSubnetMask('255.255.255.1')  // ✗ invalidSubnetMask
+```
+
+### Email Validator
+
+```dart
+class EmailValidator {
+  // Valida email genérico
+  static ValidationResult<String> validate(String value)
+  
+  // Valida email de domínio específico
+  static ValidationResult<String> validateDomain(String value, String domain)
+  
+  // Valida email de um dos domínios permitidos
+  static ValidationResult<String> validateDomains(
+    String value,
+    List<String> domains,
+  )
+}
+```
+
+**Exemplos**:
+```dart
+// Email válido
+EmailValidator.validate('user@example.com')                // ✓
+
+// Validate domínio específico
+EmailValidator.validateDomain('user@example.com', 'example.com')  // ✓
+EmailValidator.validateDomain('user@other.com', 'example.com')    // ✗
+
+// Validate múltiplos domínios
+EmailValidator.validateDomains(
+  'user@gmail.com',
+  ['gmail.com', 'yahoo.com'],
+)  // ✓
+```
+
+### URL Validator
+
+```dart
+class UrlValidator {
+  // Valida URL genérica
+  static ValidationResult<UrlValidationResult> validate(
+    String value,
+    {bool requireScheme = false, List<String>? allowedSchemes}
+  )
+  
+  // Valida URL HTTP/HTTPS
+  static ValidationResult<UrlValidationResult> validateHttpUrl(String value)
+  
+  // Valida URL com schema específico
+  static ValidationResult<UrlValidationResult> validateUrlWithScheme(
+    String value,
+    String scheme,
+  )
+}
+```
+
+**Exemplos**:
+```dart
+// URL genérica
+UrlValidator.validate('http://example.com')         // ✓
+UrlValidator.validate('https://example.com:8080')   // ✓
+
+// HTTP/HTTPS
+UrlValidator.validateHttpUrl('https://example.com')  // ✓
+UrlValidator.validateHttpUrl('ftp://example.com')    // ✗
+
+// Schema específico
+UrlValidator.validateUrlWithScheme('mqtt://broker.com', 'mqtt')  // ✓
+```
+
+### Password Validator
+
+```dart
+class PasswordValidator {
+  // Valida com requisitos customizáveis
+  static ValidationResult<PasswordValidationResult> validate(
+    String value,
+    [PasswordRequirements requirements = PasswordRequirements.medium]
+  )
+  
+  // Valida com requisitos fortes
+  static ValidationResult<PasswordValidationResult> validateStrong(String value)
+  
+  // Valida com requisitos moderados (padrão)
+  static ValidationResult<PasswordValidationResult> validateMedium(String value)
+}
+```
+
+**Requisitos Predefinidos**:
+
+```dart
+// Forte: 12+ chars, maiúsculas, minúsculas, números, especiais
+PasswordRequirements.strong
+
+// Moderado (padrão): 8+ chars, maiúsculas, minúsculas, números
+PasswordRequirements.medium
+
+// Fraco: 6+ chars, sem requisitos adicionais
+PasswordRequirements.weak
+
+// Custom
+const custom = PasswordRequirements(
+  minLength: 10,
+  requireUppercase: true,
+  requireLowercase: true,
+  requireNumbers: false,
+  requireSpecialCharacters: true,
+  specialCharacters: '!@#$%',
+);
+```
+
+**Exemplos**:
+```dart
+// Validação simples
+PasswordValidator.validateMedium('MyPassword123')  // ✓
+
+// Com força calculada
+final result = PasswordValidator.validate('XyZ#Abc9@123');
+result.fold(
+  (_) => print('Inválida'),
+  (pwd) => print('Força: ${pwd.strength}/100'),
+);
+
+// Com requisitos customizados
+final custom = PasswordRequirements(minLength: 12);
+PasswordValidator.validate('MyPassword123', custom)  // ✓
+```
+
+---
+
+## Tratamento de Erros
+
+### Padrão Either Monad
+
+```dart
+final result = IpValidator.validate('192.168.1.1');
+
+// Padrão 1: fold
+result.fold(
+  (error) => handleError(error),        // Left - erro
+  (value) => handleSuccess(value),      // Right - sucesso
+);
+
+// Padrão 2: match (equiv. a fold)
+result.match(
+  (error) => handleError(error),
+  (value) => handleSuccess(value),
+);
+
+// Padrão 3: verificação de estado
+if (result.isValid) {
+  final value = result.value;  // T?
+}
+
+if (result.isInvalid) {
+  final error = result.error;  // ValidationError?
+}
+```
+
+### Erro com Detalhes (Optional)
+
+Ao capturar validações no nível mais alto (ex: BLoC/Presenter), pode-se usar:
+
+```dart
+// Em lib/src/errors/errors.dart
+class ErrorValidationData extends ErrorBase {
+  final String fieldType;      // 'ip', 'email', 'password', etc
+  final String message;        // Mensagem tratada
+  final String? invalidValue;  // Valor que falhou (opcional por segurança)
+}
+
+// Exemplo de uso em um BLoC:
+try {
+  final ipResult = IpValidator.validate(userInput);
+  ipResult.fold(
+    (error) => emit(ErrorState(
+      ErrorValidationData(
+        fieldType: 'ip_address',
+        message: error.description,
+        invalidValue: userInput,
+      ),
+    )),
+    (value) => emit(SuccessState(value)),
+  );
+} catch (e) {
+  // Handle unexpected errors
+}
+```
+
+---
+
+## Casos de Uso Complexos
+
+Para validações que encapsulam múltiplos validators:
+
+```dart
+class NetworkConfigValidator {
+  static ValidationResult<NetworkConfig> validateNetworkConfig({
+    required String ipAddress,
+    required String subnetMask,
+    required String gateway,
+  }) {
+    // Valida cada campo
+    final ipValidation = IpValidator.validateIpv4(ipAddress);
+    if (ipValidation.isInvalid) {
+      return const Left(ValidationError.invalidIp);
+    }
+
+    final maskValidation = IpValidator.validateSubnetMask(subnetMask);
+    if (maskValidation.isInvalid) {
+      return const Left(ValidationError.invalidSubnetMask);
+    }
+
+    final gatewayValidation = IpValidator.validateIpv4(gateway);
+    if (gatewayValidation.isInvalid) {
+      return const Left(ValidationError.invalidGateway);
+    }
+
+    // Retorna config validada
+    return Right(
+      NetworkConfig(
+        ipAddress: ipValidation.value!,
+        subnetMask: maskValidation.value!,
+        gateway: gatewayValidation.value!,
+      ),
+    );
+  }
+}
+
+// Uso
+final result = NetworkConfigValidator.validateNetworkConfig(
+  ipAddress: '192.168.1.100',
+  subnetMask: '255.255.255.0',
+  gateway: '192.168.1.1',
+);
+```
+
+---
+
+## Testes
+
+Todos os validators têm testes unitários em:
+```
+test/src/domain/validators/
+├── ip_validator_test.dart
+├── email_validator_test.dart
+├── url_validator_test.dart
+└── password_validator_test.dart
+```
+
+**Executar testes**:
+```bash
+flutter test
+# ou especificamente
+flutter test test/src/domain/validators/
+```
+
+---
+
+## Integração com BLoC
+
+Exemplo de uso em um BLoC de formulário:
+
+```dart
+class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
+  SettingsBloc() : super(const SettingsInitial()) {
+    on<ValidateIpEvent>(_onValidateIp);
+  }
+
+  Future<void> _onValidateIp(
+    ValidateIpEvent event,
+    Emitter<SettingsState> emit,
+  ) async {
+    final result = IpValidator.validate(event.ipInput);
+    
+    result.fold(
+      (error) => emit(
+        SettingsError(
+          message: 'IP inválido: ${error.description}',
+        ),
+      ),
+      (ipResult) => emit(
+        SettingsSuccess(
+          message: 'IP válido: ${ipResult.ip}',
+        ),
+      ),
+    );
+  }
+}
+```
+
+---
+
+## Próximas Fases
+
+1. **Validation Usecases**: Encapsular lógicas complexas (ex: `ValidateNetworkConfig`)
+2. **Async Validators**: Suporte para validações assíncronas (ex: verificar SSID disponível)
+3. **Custom Validators**: API para usuários criarem validators customizados
+4. **Mensagens Internacionalizadas**: I18n para mensagens de erro
+5. **Performance**: Cache de regex, compilação otimizada
+
+---
+
+## Referências
+
+- **Validators**: [lib/src/domain/validators/](lib/src/domain/validators/)
+- **Erros**: [lib/ciot_errors.dart](../../../lib/ciot_errors.dart)
+- **Testes**: [test/src/domain/validators/](../../../test/src/domain/validators/)
+- **Exemplo Completo**: [lib/src/domain/validators/validators_example.dart](lib/src/domain/validators/validators_example.dart)

--- a/lib/src/domain/validators/email_validator.dart
+++ b/lib/src/domain/validators/email_validator.dart
@@ -1,0 +1,73 @@
+import 'package:fpdart/fpdart.dart';
+
+import 'validation_error.dart';
+import 'validation_result.dart';
+
+/// Validates email addresses
+class EmailValidator {
+  /// Simplified but functional email pattern.
+  /// Does not fully comply with RFC 5322, but covers 99% of real-world cases.
+  static final _emailRegex = RegExp(
+    r'^[a-zA-Z0-9.!#$%&*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$',
+  );
+
+  /// Validates whether the value is a valid email address
+  static ValidationResult<String> validate(String value) {
+    final trimmed = value.trim();
+
+    if (trimmed.isEmpty) {
+      return const Left(ValidationError.emptyValue);
+    }
+
+    if (trimmed.length > 254) {
+      return const Left(ValidationError.invalidLength);
+    }
+
+    if (!_emailRegex.hasMatch(trimmed)) {
+      return const Left(ValidationError.invalidEmail);
+    }
+
+    // Validate local part length (before the @)
+    final parts = trimmed.split('@');
+    if (parts[0].length > 64) {
+      return const Left(ValidationError.invalidLength);
+    }
+
+    return Right(trimmed);
+  }
+
+  /// Validates an email address against a specific domain
+  static ValidationResult<String> validateDomain(
+    String value,
+    String domain,
+  ) {
+    final validationResult = validate(value);
+    return validationResult.fold(
+      (error) => Left(error),
+      (email) {
+        if (email.split('@')[1] != domain) {
+          return const Left(ValidationError.invalidEmail);
+        }
+        return Right(email);
+      },
+    );
+  }
+
+  /// Validates an email address against a list of allowed domains
+  static ValidationResult<String> validateDomains(
+    String value,
+    List<String> domains,
+  ) {
+    final validationResult = validate(value);
+    return validationResult.fold(
+      (error) => Left(error),
+      (email) {
+        final emailDomain = email.split('@')[1];
+        if (!domains.contains(emailDomain)) {
+          return const Left(ValidationError.invalidEmail);
+        }
+        return Right(email);
+      },
+    );
+  }
+}

--- a/lib/src/domain/validators/ip_validator.dart
+++ b/lib/src/domain/validators/ip_validator.dart
@@ -1,0 +1,146 @@
+import 'package:fpdart/fpdart.dart';
+
+import 'validation_error.dart';
+import 'validation_result.dart';
+
+/// Result of an IP address validation
+class IpValidationResult {
+  final String ip;
+  final bool isIpv4;
+  final bool isIpv6;
+
+  const IpValidationResult({
+    required this.ip,
+    required this.isIpv4,
+    required this.isIpv6,
+  });
+}
+
+/// Validates IP addresses (IPv4 and IPv6)
+class IpValidator {
+  /// IPv4 pattern: 0.0.0.0 to 255.255.255.255
+  static final _ipv4Regex = RegExp(
+    r'^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}'
+    r'(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$',
+  );
+
+  /// Simplified IPv6 pattern (supports compressed and expanded forms)
+  static final _ipv6Regex = RegExp(
+    r'^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|'
+    r'([0-9a-fA-F]{1,4}:){1,7}:|'
+    r'([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|'
+    r'([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|'
+    r'([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|'
+    r'([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|'
+    r'([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|'
+    r'[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|'
+    r':((:[0-9a-fA-F]{1,4}){1,7}|:)|'
+    r'fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|'
+    r'::(ffff(:0{1,4}){0,1}:){0,1}'
+    r'((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}'
+    r'(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|'
+    r'([0-9a-fA-F]{1,4}:){1,4}:'
+    r'((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}'
+    r'(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$',
+  );
+
+  /// Validates whether the value is a valid IP address (IPv4 or IPv6)
+  static ValidationResult<IpValidationResult> validate(String value) {
+    final trimmed = value.trim();
+
+    if (trimmed.isEmpty) {
+      return const Left(ValidationError.emptyValue);
+    }
+
+    final isIpv4 = _ipv4Regex.hasMatch(trimmed);
+    final isIpv6 = _ipv6Regex.hasMatch(trimmed);
+
+    if (!isIpv4 && !isIpv6) {
+      return const Left(ValidationError.invalidIp);
+    }
+
+    return Right(
+      IpValidationResult(
+        ip: trimmed,
+        isIpv4: isIpv4,
+        isIpv6: isIpv6,
+      ),
+    );
+  }
+
+  /// Validates specifically an IPv4 address
+  static ValidationResult<String> validateIpv4(String value) {
+    final trimmed = value.trim();
+
+    if (trimmed.isEmpty) {
+      return const Left(ValidationError.emptyValue);
+    }
+
+    if (!_ipv4Regex.hasMatch(trimmed)) {
+      return const Left(ValidationError.invalidIp);
+    }
+
+    return Right(trimmed);
+  }
+
+  /// Validates specifically an IPv6 address
+  static ValidationResult<String> validateIpv6(String value) {
+    final trimmed = value.trim();
+
+    if (trimmed.isEmpty) {
+      return const Left(ValidationError.emptyValue);
+    }
+
+    if (!_ipv6Regex.hasMatch(trimmed)) {
+      return const Left(ValidationError.invalidIp);
+    }
+
+    return Right(trimmed);
+  }
+
+  /// Validates a subnet mask in CIDR or dotted-decimal format
+  static ValidationResult<String> validateSubnetMask(String value) {
+    final trimmed = value.trim();
+
+    if (trimmed.isEmpty) {
+      return const Left(ValidationError.emptyValue);
+    }
+
+    // CIDR format: /24, /32, etc.
+    if (trimmed.startsWith('/')) {
+      try {
+        final prefix = int.parse(trimmed.substring(1));
+        if (prefix < 0 || prefix > 32) {
+          return const Left(ValidationError.invalidSubnetMask);
+        }
+        return Right(trimmed);
+      } catch (_) {
+        return const Left(ValidationError.invalidSubnetMask);
+      }
+    }
+
+    // Dotted-decimal format: 255.255.255.0
+    if (!_ipv4Regex.hasMatch(trimmed)) {
+      return const Left(ValidationError.invalidSubnetMask);
+    }
+
+    // Validate that bits are contiguous (1s followed by 0s)
+    final parts = trimmed.split('.');
+    int bitmask = 0;
+    for (var i = 0; i < 4; i++) {
+      try {
+        bitmask = (bitmask << 8) | int.parse(parts[i]);
+      } catch (_) {
+        return const Left(ValidationError.invalidSubnetMask);
+      }
+    }
+
+    // Check if the bitmask is a valid subnet mask (contiguous bit pattern)
+    final inverted = (~bitmask) & 0xFFFFFFFF;
+    if ((inverted + 1) & inverted != 0) {
+      return const Left(ValidationError.invalidSubnetMask);
+    }
+
+    return Right(trimmed);
+  }
+}

--- a/lib/src/domain/validators/password_validator.dart
+++ b/lib/src/domain/validators/password_validator.dart
@@ -1,0 +1,216 @@
+import 'package:fpdart/fpdart.dart';
+
+import 'validation_error.dart';
+import 'validation_result.dart';
+
+/// Password validation requirements configuration
+class PasswordRequirements {
+  /// Minimum password length (default: 8)
+  final int minLength;
+
+  /// Maximum password length (default: 128)
+  final int maxLength;
+
+  /// Must contain uppercase letters
+  final bool requireUppercase;
+
+  /// Must contain lowercase letters
+  final bool requireLowercase;
+
+  /// Must contain numbers
+  final bool requireNumbers;
+
+  /// Must contain special characters
+  final bool requireSpecialCharacters;
+
+  /// Allowed special characters
+  final String specialCharacters;
+
+  const PasswordRequirements({
+    this.minLength = 8,
+    this.maxLength = 128,
+    this.requireUppercase = true,
+    this.requireLowercase = true,
+    this.requireNumbers = true,
+    this.requireSpecialCharacters = false,
+    this.specialCharacters = r'!@#$%^&*()_+-=[]{}|;:,.<>?',
+  });
+
+  /// Strong requirements (highly secure)
+  static const PasswordRequirements strong = PasswordRequirements(
+    minLength: 12,
+    requireUppercase: true,
+    requireLowercase: true,
+    requireNumbers: true,
+    requireSpecialCharacters: true,
+  );
+
+  /// Moderate requirements
+  static const PasswordRequirements medium = PasswordRequirements(
+    minLength: 8,
+    requireUppercase: true,
+    requireLowercase: true,
+    requireNumbers: true,
+    requireSpecialCharacters: false,
+  );
+
+  /// Weak requirements (minimum length only)
+  static const PasswordRequirements weak = PasswordRequirements(
+    minLength: 6,
+    requireUppercase: false,
+    requireLowercase: false,
+    requireNumbers: false,
+    requireSpecialCharacters: false,
+  );
+}
+
+/// Result of a password validation, including details of which requirements failed
+class PasswordValidationResult {
+  final String password;
+  final bool isValid;
+  final List<String> failedRequirements;
+  final int strength;
+
+  const PasswordValidationResult({
+    required this.password,
+    required this.isValid,
+    required this.failedRequirements,
+    required this.strength,
+  });
+}
+
+/// Validates passwords against customizable requirements
+class PasswordValidator {
+  static final _uppercaseRegex = RegExp(r'[A-Z]');
+  static final _lowercaseRegex = RegExp(r'[a-z]');
+  static final _numbersRegex = RegExp(r'\d');
+
+  /// Validates a password against the given requirements
+  static ValidationResult<PasswordValidationResult> validate(
+    String value, [
+    PasswordRequirements requirements = PasswordRequirements.medium,
+  ]) {
+    final trimmed = value;
+
+    if (trimmed.isEmpty) {
+      return const Left(ValidationError.emptyValue);
+    }
+
+    final failedRequirements = <String>[];
+
+    // Validate length
+    if (trimmed.length < requirements.minLength) {
+      failedRequirements.add(
+        'Minimum ${requirements.minLength} characters required',
+      );
+    }
+
+    if (trimmed.length > requirements.maxLength) {
+      failedRequirements.add(
+        'Maximum ${requirements.maxLength} characters allowed',
+      );
+    }
+
+    // Validate uppercase letters
+    if (requirements.requireUppercase && !_uppercaseRegex.hasMatch(trimmed)) {
+      failedRequirements.add('Must contain uppercase letters (A-Z)');
+    }
+
+    // Validate lowercase letters
+    if (requirements.requireLowercase && !_lowercaseRegex.hasMatch(trimmed)) {
+      failedRequirements.add('Must contain lowercase letters (a-z)');
+    }
+
+    // Validate numbers
+    if (requirements.requireNumbers && !_numbersRegex.hasMatch(trimmed)) {
+      failedRequirements.add('Must contain numbers (0-9)');
+    }
+
+    // Validate special characters
+    if (requirements.requireSpecialCharacters) {
+      final hasSpecial = requirements.specialCharacters.split('').any((char) => trimmed.contains(char));
+
+      if (!hasSpecial) {
+        failedRequirements.add('Must contain special characters');
+      }
+    }
+
+    if (failedRequirements.isNotEmpty) {
+      return const Left(ValidationError.invalidPassword);
+    }
+
+    // Calcula força da senha (0-100)
+    final strength = _calculateStrength(trimmed, requirements);
+
+    return Right(
+      PasswordValidationResult(
+        password: trimmed,
+        isValid: true,
+        failedRequirements: [],
+        strength: strength,
+      ),
+    );
+  }
+
+  /// Validates a password against strong requirements
+  static ValidationResult<PasswordValidationResult> validateStrong(
+    String value,
+  ) {
+    return validate(value, PasswordRequirements.strong);
+  }
+
+  /// Validates a password against moderate requirements
+  static ValidationResult<PasswordValidationResult> validateMedium(
+    String value,
+  ) {
+    return validate(value, PasswordRequirements.medium);
+  }
+
+  /// Calculates password strength score (0-100)
+  static int _calculateStrength(
+    String password,
+    PasswordRequirements requirements,
+  ) {
+    int score = 0;
+
+    // Length score
+    if (password.length >= requirements.minLength) {
+      score += 20;
+    }
+    if (password.length >= requirements.minLength + 4) {
+      score += 10;
+    }
+
+    // Character variety
+    if (_uppercaseRegex.hasMatch(password)) score += 15;
+    if (_lowercaseRegex.hasMatch(password)) score += 15;
+    if (_numbersRegex.hasMatch(password)) score += 15;
+
+    if (requirements.specialCharacters.split('').any((char) => password.contains(char))) {
+      score += 25;
+    }
+
+    // Penalize common patterns
+    if (_isCommonPattern(password)) {
+      score = (score * 0.7).toInt();
+    }
+
+    return score.clamp(0, 100);
+  }
+
+  /// Checks whether the password contains common weak patterns
+  static bool _isCommonPattern(String password) {
+    final weak = [
+      'password',
+      '123456',
+      '111111',
+      'qwerty',
+      'abc123',
+      'admin',
+      '000000',
+    ];
+
+    final lower = password.toLowerCase();
+    return weak.any((pattern) => lower.contains(pattern));
+  }
+}

--- a/lib/src/domain/validators/url_validator.dart
+++ b/lib/src/domain/validators/url_validator.dart
@@ -1,0 +1,91 @@
+import 'package:fpdart/fpdart.dart';
+
+import 'validation_error.dart';
+import 'validation_result.dart';
+
+/// Result of a URL validation
+class UrlValidationResult {
+  final String url;
+  final Uri uri;
+  final String? scheme;
+  final String? host;
+
+  const UrlValidationResult({
+    required this.url,
+    required this.uri,
+    required this.scheme,
+    required this.host,
+  });
+}
+
+/// Validates URLs
+class UrlValidator {
+  /// Validates whether the value is a valid URL
+  static ValidationResult<UrlValidationResult> validate(
+    String value, {
+    bool requireScheme = false,
+    List<String>? allowedSchemes,
+  }) {
+    final trimmed = value.trim();
+
+    if (trimmed.isEmpty) {
+      return const Left(ValidationError.emptyValue);
+    }
+
+    // Attempt to parse as URI
+    Uri? uri;
+    try {
+      uri = Uri.parse(trimmed);
+
+      // Validate scheme
+      if (uri.scheme.isEmpty && requireScheme) {
+        return const Left(ValidationError.invalidUrl);
+      }
+
+      if (allowedSchemes != null && uri.scheme.isNotEmpty) {
+        if (!allowedSchemes.contains(uri.scheme)) {
+          return const Left(ValidationError.invalidUrl);
+        }
+      }
+
+      // Check that the URL has a host
+      if (uri.host.isEmpty) {
+        return const Left(ValidationError.invalidUrl);
+      }
+
+      return Right(
+        UrlValidationResult(
+          url: trimmed,
+          uri: uri,
+          scheme: uri.scheme.isEmpty ? null : uri.scheme,
+          host: uri.host.isEmpty ? null : uri.host,
+        ),
+      );
+    } catch (_) {
+      return const Left(ValidationError.invalidUrl);
+    }
+  }
+
+  /// Validates an HTTP or HTTPS URL
+  static ValidationResult<UrlValidationResult> validateHttpUrl(
+    String value,
+  ) {
+    return validate(
+      value,
+      requireScheme: true,
+      allowedSchemes: ['http', 'https'],
+    );
+  }
+
+  /// Validates a URL with a specific scheme (e.g. ftp, mqtt)
+  static ValidationResult<UrlValidationResult> validateUrlWithScheme(
+    String value,
+    String scheme,
+  ) {
+    return validate(
+      value,
+      requireScheme: true,
+      allowedSchemes: [scheme],
+    );
+  }
+}

--- a/lib/src/domain/validators/validation_error.dart
+++ b/lib/src/domain/validators/validation_error.dart
@@ -1,0 +1,56 @@
+/// Error types that can occur during a validation
+enum ValidationError {
+  /// Invalid IP address (not a valid IPv4 or IPv6)
+  invalidIp,
+
+  /// Invalid URL
+  invalidUrl,
+
+  /// Invalid email address
+  invalidEmail,
+
+  /// Weak or invalid password
+  invalidPassword,
+
+  /// Empty value when a non-empty value is required
+  emptyValue,
+
+  /// Invalid subnet mask
+  invalidSubnetMask,
+
+  /// Invalid gateway IP address
+  invalidGateway,
+
+  /// Invalid WiFi SSID
+  invalidSsid,
+
+  /// Invalid port number
+  invalidPort,
+
+  /// Value length is outside the accepted range
+  invalidLength,
+
+  /// Value contains disallowed characters
+  invalidCharacters,
+
+  /// Generic validation error
+  generic;
+
+  /// Human-readable description of the validation error
+  String get description {
+    return switch (this) {
+      invalidIp => 'Invalid IP address',
+      invalidUrl => 'Invalid URL',
+      invalidEmail => 'Invalid email address',
+      invalidPassword => 'Weak or invalid password',
+      emptyValue => 'Value cannot be empty',
+      invalidSubnetMask => 'Invalid subnet mask',
+      invalidGateway => 'Invalid gateway',
+      invalidSsid => 'Invalid SSID',
+      invalidPort => 'Invalid port',
+      invalidLength => 'Invalid character length',
+      invalidCharacters => 'Contains disallowed characters',
+      generic => 'Validation failed',
+    };
+  }
+}

--- a/lib/src/domain/validators/validation_result.dart
+++ b/lib/src/domain/validators/validation_result.dart
@@ -1,0 +1,24 @@
+import 'package:fpdart/fpdart.dart';
+
+import 'validation_error.dart';
+
+/// Result of a validation operation.
+///
+/// - [Left<ValidationError>] indicates that validation failed
+/// - [Right<T>] indicates that validation passed and holds the validated value
+typedef ValidationResult<T> = Either<ValidationError, T>;
+
+/// Extension helpers for working with [ValidationResult]
+extension ValidationResultX<T> on ValidationResult<T> {
+  /// Returns true if validation passed
+  bool get isValid => fold((_) => false, (_) => true);
+
+  /// Returns true if validation failed
+  bool get isInvalid => !isValid;
+
+  /// Returns the error if validation failed, otherwise null
+  ValidationError? get error => fold((e) => e, (_) => null);
+
+  /// Returns the value if validation passed, otherwise null
+  T? get value => fold((_) => null, (v) => v);
+}

--- a/lib/src/domain/validators/validator.dart
+++ b/lib/src/domain/validators/validator.dart
@@ -1,0 +1,9 @@
+import 'validation_result.dart';
+
+/// Base type for a synchronous validator function.
+///
+/// A validator receives a value of type [T] and returns a [ValidationResult]
+/// indicating whether the value is valid or which error occurred.
+typedef Validator<T> = ValidationResult<T> Function(T value);
+
+/// Base type for an asynchronous validator function.

--- a/lib/src/domain/validators/validators.dart
+++ b/lib/src/domain/validators/validators.dart
@@ -1,0 +1,7 @@
+export 'email_validator.dart';
+export 'ip_validator.dart';
+export 'password_validator.dart';
+export 'url_validator.dart';
+export 'validation_error.dart';
+export 'validation_result.dart';
+export 'validator.dart';

--- a/lib/src/domain/validators/validators_example.dart
+++ b/lib/src/domain/validators/validators_example.dart
@@ -1,0 +1,243 @@
+// ignore_for_file: creation_with_non_type, unused_local_variable, avoid_print, dangling_library_doc_comments
+/// Example usage of the validation system in the GPIO test
+///
+/// This file demonstrates how to use CIOT validators to validate
+/// user input before saving network configurations.
+
+import 'package:ciot_dart/ciot.dart';
+import 'package:fpdart/fpdart.dart';
+
+/// Example: Network configuration validator
+class NetworkConfigValidator {
+  /// Validates a complete network configuration
+  static ValidationResult<NetworkConfig> validateNetworkConfig({
+    required String ipAddress,
+    required String subnetMask,
+    required String gateway,
+  }) {
+    // Validate IP address first
+    final ipValidation = IpValidator.validateIpv4(ipAddress);
+    if (ipValidation.isInvalid) {
+      return const Left(ValidationError.invalidIp);
+    }
+
+    // Validate subnet mask
+    final maskValidation = IpValidator.validateSubnetMask(subnetMask);
+    if (maskValidation.isInvalid) {
+      return const Left(ValidationError.invalidSubnetMask);
+    }
+
+    // Validate gateway
+    final gatewayValidation = IpValidator.validateIpv4(gateway);
+    if (gatewayValidation.isInvalid) {
+      return const Left(ValidationError.invalidGateway);
+    }
+
+    return Right(
+      NetworkConfig(
+        ipAddress: ipValidation.value!,
+        subnetMask: maskValidation.value!,
+        gateway: gatewayValidation.value!,
+      ),
+    );
+  }
+}
+
+/// Validated network configuration model
+class NetworkConfig {
+  final String ipAddress;
+  final String subnetMask;
+  final String gateway;
+
+  NetworkConfig({
+    required this.ipAddress,
+    required this.subnetMask,
+    required this.gateway,
+  });
+}
+
+/// Example: WiFi credentials validator
+class WifiCredentialsValidator {
+  /// Validates a WiFi SSID
+  static ValidationResult<String> validateSsid(String ssid) {
+    const maxSsidLength = 32;
+    final trimmed = ssid.trim();
+
+    if (trimmed.isEmpty) {
+      return const Left(ValidationError.emptyValue);
+    }
+
+    if (trimmed.length > maxSsidLength) {
+      return const Left(ValidationError.invalidLength);
+    }
+
+    return Right(trimmed);
+  }
+
+  /// Validates a WiFi password
+  static ValidationResult<String> validatePassword(String password) {
+    return PasswordValidator.validate(password).fold(
+      (error) => Left(error),
+      (result) => Right(result.password),
+    );
+  }
+
+  /// Validates SSID and password together
+  static ValidationResult<WifiCredentials> validateWifiCredentials({
+    required String ssid,
+    required String password,
+  }) {
+    final ssidValidation = validateSsid(ssid);
+    if (ssidValidation.isInvalid) {
+      return const Left(ValidationError.invalidSsid);
+    }
+
+    final passwordValidation = validatePassword(password);
+    if (passwordValidation.isInvalid) {
+      return const Left(ValidationError.invalidPassword);
+    }
+
+    return Right(
+      WifiCredentials(
+        ssid: ssidValidation.value!,
+        password: passwordValidation.value!,
+      ),
+    );
+  }
+}
+
+/// Validated WiFi credentials model
+class WifiCredentials {
+  final String ssid;
+  final String password;
+
+  WifiCredentials({
+    required this.ssid,
+    required this.password,
+  });
+}
+
+/// Example: MQTT configuration validator
+class MqttConfigValidator {
+  /// Validates a complete MQTT configuration
+  static ValidationResult<MqttConfig> validateMqttConfig({
+    required String brokerUrl,
+    required String clientId,
+    String? username,
+    String? password,
+  }) {
+    // Validate broker URL (must use the mqtt scheme)
+    final urlValidation = UrlValidator.validateUrlWithScheme(brokerUrl, 'mqtt');
+    if (urlValidation.isInvalid) {
+      return const Left(ValidationError.invalidUrl);
+    }
+
+    // clientId must be non-empty
+    if (clientId.trim().isEmpty) {
+      return const Left(ValidationError.emptyValue);
+    }
+
+    // If a username is provided, optionally validate as email
+    if (username != null && username.isNotEmpty) {
+      // Accept both email addresses and plain usernames
+      final emailValidation = EmailValidator.validate(username);
+    }
+
+    // If a password is provided, validate minimum strength
+    if (password != null && password.isNotEmpty) {
+      // MQTT brokers generally accept weak passwords
+      final passwordValidation = PasswordValidator.validate(
+        password,
+        PasswordRequirements.weak,
+      );
+      if (passwordValidation.isInvalid) {
+        return const Left(ValidationError.invalidPassword);
+      }
+    }
+
+    return Right(
+      MqttConfig(
+        brokerUrl: urlValidation.value!.url,
+        clientId: clientId.trim(),
+        username: username?.trim(),
+        password: password?.trim(),
+      ),
+    );
+  }
+}
+
+/// Validated MQTT configuration model
+class MqttConfig {
+  final String brokerUrl;
+  final String clientId;
+  final String? username;
+  final String? password;
+
+  MqttConfig({
+    required this.brokerUrl,
+    required this.clientId,
+    this.username,
+    this.password,
+  });
+}
+
+/// Example usage in a form
+void exampleFormValidation() {
+  // Example 1: Validate IP address
+  print('=== Validating IP ===');
+  final ipResult = IpValidator.validate('192.168.1.100');
+  ipResult.fold(
+    (error) => print('Error: ${error.description}'),
+    (result) => print('Valid IP: ${result.ip} (IPv4: ${result.isIpv4})'),
+  );
+
+  // Example 2: Validate Email
+  print('\n=== Validating Email ===');
+  final emailResult = EmailValidator.validate('user@example.com');
+  emailResult.fold(
+    (error) => print('Error: ${error.description}'),
+    (email) => print('Valid email: $email'),
+  );
+
+  // Example 3: Validate Password
+  print('\n=== Validating Password ===');
+  final passwordResult = PasswordValidator.validateStrong('MyP@ssw0rd123');
+  passwordResult.fold(
+    (error) => print('Error: ${error.description}'),
+    (result) {
+      print('Valid password!');
+      print('Strength: ${result.strength}/100');
+    },
+  );
+
+  // Example 4: Validate Network Configuration
+  print('\n=== Validating Network Config ===');
+  final networkResult = NetworkConfigValidator.validateNetworkConfig(
+    ipAddress: '192.168.1.100',
+    subnetMask: '255.255.255.0',
+    gateway: '192.168.1.1',
+  );
+  networkResult.fold(
+    (error) => print('Error: ${error.description}'),
+    (config) {
+      print('Valid config!');
+      print('IP: ${config.ipAddress}');
+      print('Subnet: ${config.subnetMask}');
+      print('Gateway: ${config.gateway}');
+    },
+  );
+
+  // Example 5: Validate WiFi Credentials
+  print('\n=== Validating WiFi Credentials ===');
+  final wifiResult = WifiCredentialsValidator.validateWifiCredentials(
+    ssid: 'MyWiFiNetwork',
+    password: 'SecurePass123!',
+  );
+  wifiResult.fold(
+    (error) => print('Error: ${error.description}'),
+    (creds) {
+      print('Valid credentials!');
+      print('SSID: ${creds.ssid}');
+    },
+  );
+}

--- a/lib/src/errors/errors.dart
+++ b/lib/src/errors/errors.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+
 import 'package:ciot_dart/generated/ciot/proto/v2/errors.pbenum.dart';
 
 abstract class ErrorBase {}
@@ -10,7 +11,7 @@ class ErrorInvalidType implements ErrorBase {}
 class ErrorHttpRequest implements ErrorBase {
   final int status;
   final Uint8List body;
-  ErrorHttpRequest(this.status,this.body);
+  ErrorHttpRequest(this.status, this.body);
 }
 
 class ErrorException implements ErrorBase {
@@ -35,6 +36,24 @@ class ErrorInvalidState implements ErrorBase {}
 class ErrorBusy implements ErrorBase {}
 
 class ErrorValidation extends ErrorBase {}
+
+/// Validation error with details about the field and type of failure
+class ErrorValidationData extends ErrorBase {
+  /// The type of field that failed validation (e.g. 'ip', 'url', 'email', 'password')
+  final String fieldType;
+
+  /// Descriptive error message
+  final String message;
+
+  /// The invalid value that was provided (may be omitted for security reasons)
+  final String? invalidValue;
+
+  ErrorValidationData({
+    required this.fieldType,
+    required this.message,
+    this.invalidValue,
+  });
+}
 
 class ErrorCredentials extends ErrorBase {}
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ciot_dart
 description: "A new Flutter package project."
-version: 1.1.0+10
+version: 1.1.0+11
 publish_to: none
 
 environment:

--- a/test/src/domain/validators/email_validator_test.dart
+++ b/test/src/domain/validators/email_validator_test.dart
@@ -1,0 +1,101 @@
+import 'package:ciot_dart/src/domain/validators/validators.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('EmailValidator', () {
+    group('validate', () {
+      test('valida email simples', () {
+        final result = EmailValidator.validate('user@example.com');
+        expect(result.isValid, true);
+        expect(result.value, 'user@example.com');
+      });
+
+      test('valida email com números', () {
+        final result = EmailValidator.validate('user123@example.com');
+        expect(result.isValid, true);
+      });
+
+      test('valida email com ponto no usuário', () {
+        final result = EmailValidator.validate('user.name@example.com');
+        expect(result.isValid, true);
+      });
+
+      test('valida email com hífen no domínio', () {
+        final result = EmailValidator.validate('user@example-domain.com');
+        expect(result.isValid, true);
+      });
+
+      test('valida email com subdomínio', () {
+        final result = EmailValidator.validate('user@mail.example.com');
+        expect(result.isValid, true);
+      });
+
+      test('rejeita email sem @', () {
+        final result = EmailValidator.validate('userexample.com');
+        expect(result.isInvalid, true);
+        expect(result.error, ValidationError.invalidEmail);
+      });
+
+      test('rejeita email com múltiplos @', () {
+        final result = EmailValidator.validate('user@@example.com');
+        expect(result.isInvalid, true);
+      });
+
+      test('rejeita email vazio', () {
+        final result = EmailValidator.validate('');
+        expect(result.error, ValidationError.emptyValue);
+      });
+
+      test('rejeita email apenas espaços', () {
+        final result = EmailValidator.validate('   ');
+        expect(result.error, ValidationError.emptyValue);
+      });
+
+      test('rejeita email com domínio inválido', () {
+        final result = EmailValidator.validate('user@');
+        expect(result.isInvalid, true);
+      });
+
+      test('rejeita email muito longo (> 254 caracteres)', () {
+        final longEmail = '${'a' * 200}@example.com'; // 207 caracteres após o @
+        final result = EmailValidator.validate(longEmail);
+        expect(result.isInvalid, true);
+      });
+
+      test('trim whitespace', () {
+        final result = EmailValidator.validate('  user@example.com  ');
+        expect(result.isValid, true);
+      });
+    });
+
+    group('validateDomain', () {
+      test('valida email com domínio específico', () {
+        final result = EmailValidator.validateDomain('user@example.com', 'example.com');
+        expect(result.isValid, true);
+      });
+
+      test('rejeita email com domínio diferente', () {
+        final result = EmailValidator.validateDomain('user@other.com', 'example.com');
+        expect(result.isInvalid, true);
+      });
+    });
+
+    group('validateDomains', () {
+      test('valida email com um dos domínios permitidos', () {
+        final result = EmailValidator.validateDomains(
+          'user@gmail.com',
+          ['gmail.com', 'yahoo.com'],
+        );
+        expect(result.isValid, true);
+      });
+
+      test('rejeita email com domínio não permitido', () {
+        final result = EmailValidator.validateDomains(
+          'user@example.com',
+          ['gmail.com', 'yahoo.com'],
+        );
+        expect(result.isInvalid, true);
+      });
+    });
+  });
+}

--- a/test/src/domain/validators/ip_validator_test.dart
+++ b/test/src/domain/validators/ip_validator_test.dart
@@ -1,0 +1,124 @@
+import 'package:ciot_dart/src/domain/validators/validators.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('IpValidator', () {
+    group('validate', () {
+      test('valida IPv4 válido', () {
+        final result = IpValidator.validate('192.168.1.1');
+        expect(result.isValid, true);
+        expect(result.value?.isIpv4, true);
+        expect(result.value?.isIpv6, false);
+      });
+
+      test('valida IPv4 com 0.0.0.0', () {
+        final result = IpValidator.validate('0.0.0.0');
+        expect(result.isValid, true);
+      });
+
+      test('valida IPv4 com 255.255.255.255', () {
+        final result = IpValidator.validate('255.255.255.255');
+        expect(result.isValid, true);
+      });
+
+      test('rejeita IPv4 com octeto inválido (256)', () {
+        final result = IpValidator.validate('192.168.1.256');
+        expect(result.isInvalid, true);
+        expect(result.error, ValidationError.invalidIp);
+      });
+
+      test('rejeita IPv4 incompleto', () {
+        final result = IpValidator.validate('192.168.1');
+        expect(result.isInvalid, true);
+      });
+
+      test('valida IPv6 válido (formato compactado)', () {
+        final result = IpValidator.validate('::1');
+        expect(result.isValid, true);
+        expect(result.value?.isIpv6, true);
+      });
+
+      test('valida IPv6 válido (localhost)', () {
+        final result = IpValidator.validate('2001:db8::8a2e:370:7334');
+        expect(result.isValid, true);
+      });
+
+      test('rejeita IP vazio', () {
+        final result = IpValidator.validate('');
+        expect(result.error, ValidationError.emptyValue);
+      });
+
+      test('rejeita IP apenas espaços', () {
+        final result = IpValidator.validate('   ');
+        expect(result.isInvalid, true);
+      });
+
+      test('rejeita texto inválido', () {
+        final result = IpValidator.validate('abc.def.ghi.jkl');
+        expect(result.isInvalid, true);
+      });
+
+      test('trim whitespace', () {
+        final result = IpValidator.validate('  192.168.1.1  ');
+        expect(result.isValid, true);
+      });
+    });
+
+    group('validateIpv4', () {
+      test('valida IPv4', () {
+        final result = IpValidator.validateIpv4('192.168.0.1');
+        expect(result.isValid, true);
+        expect(result.value, '192.168.0.1');
+      });
+
+      test('rejeita IPv6', () {
+        final result = IpValidator.validateIpv4('::1');
+        expect(result.isInvalid, true);
+      });
+    });
+
+    group('validateIpv6', () {
+      test('valida IPv6', () {
+        final result = IpValidator.validateIpv6('::1');
+        expect(result.isValid, true);
+      });
+
+      test('rejeita IPv4', () {
+        final result = IpValidator.validateIpv4('192.168.1.1');
+        expect(result.isValid, true);
+      });
+    });
+
+    group('validateSubnetMask', () {
+      test('valida máscara CIDR /24', () {
+        final result = IpValidator.validateSubnetMask('/24');
+        expect(result.isValid, true);
+      });
+
+      test('valida máscara CIDR /32', () {
+        final result = IpValidator.validateSubnetMask('/32');
+        expect(result.isValid, true);
+      });
+
+      test('rejeita máscara CIDR inválida /33', () {
+        final result = IpValidator.validateSubnetMask('/33');
+        expect(result.isInvalid, true);
+      });
+
+      test('valida máscara dotted decimal 255.255.255.0', () {
+        final result = IpValidator.validateSubnetMask('255.255.255.0');
+        expect(result.isValid, true);
+      });
+
+      test('valida máscara dotted decimal 255.255.0.0', () {
+        final result = IpValidator.validateSubnetMask('255.255.0.0');
+        expect(result.isValid, true);
+      });
+
+      test('rejeita máscara inválida 255.255.255.1', () {
+        final result = IpValidator.validateSubnetMask('255.255.255.1');
+        expect(result.isInvalid, true);
+      });
+    });
+  });
+}

--- a/test/src/domain/validators/password_validator_test.dart
+++ b/test/src/domain/validators/password_validator_test.dart
@@ -1,0 +1,158 @@
+import 'package:ciot_dart/src/domain/validators/validators.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('PasswordValidator', () {
+    group('validate with medium requirements', () {
+      test('aceita senha válida', () {
+        final result = PasswordValidator.validate('MyPassword123');
+        expect(result.isValid, true);
+        expect(result.value?.isValid, true);
+        expect(result.value?.failedRequirements, isEmpty);
+      });
+
+      test('rejeita senha muito curta', () {
+        final result = PasswordValidator.validate('Short1');
+        expect(result.isInvalid, true);
+        expect(result.error, ValidationError.invalidPassword);
+      });
+
+      test('rejeita senha sem maiúsculas', () {
+        final result = PasswordValidator.validate('password123');
+        expect(result.isInvalid, true);
+      });
+
+      test('rejeita senha sem minúsculas', () {
+        final result = PasswordValidator.validate('PASSWORD123');
+        expect(result.isInvalid, true);
+      });
+
+      test('rejeita senha sem números', () {
+        final result = PasswordValidator.validate('MyPassword');
+        expect(result.isInvalid, true);
+      });
+
+      test('rejeita senha vazia', () {
+        final result = PasswordValidator.validate('');
+        expect(result.error, ValidationError.emptyValue);
+      });
+    });
+
+    group('validate with strong requirements', () {
+      test('aceita senha forte', () {
+        final result = PasswordValidator.validateStrong('MyP@ssw0rd123');
+        expect(result.isValid, true);
+      });
+
+      test('rejeita senha forte sem caracteres especiais', () {
+        final result = PasswordValidator.validateStrong('MyPassword123');
+        expect(result.isInvalid, true);
+      });
+
+      test('rejeita senha forte muito curta (< 12)', () {
+        final result = PasswordValidator.validateStrong('MyP@ss1');
+        expect(result.isInvalid, true);
+      });
+    });
+
+    group('validate with weak requirements', () {
+      test('aceita qualquer senha com 6+ caracteres', () {
+        final result = PasswordValidator.validate(
+          'abc123',
+          PasswordRequirements.weak,
+        );
+        expect(result.isValid, true);
+      });
+
+      test('aceita senha com apenas números', () {
+        final result = PasswordValidator.validate(
+          '123456',
+          PasswordRequirements.weak,
+        );
+        expect(result.isValid, true);
+      });
+
+      test('rejeita senha muito curta mesmo com weak', () {
+        final result = PasswordValidator.validate(
+          'abc',
+          PasswordRequirements.weak,
+        );
+        expect(result.isInvalid, true);
+      });
+    });
+
+    group('password strength calculation', () {
+      test('calcula força baixa para senha fraca', () {
+        final result = PasswordValidator.validate(
+          'password123',
+          PasswordRequirements.weak,
+        );
+        expect(result.isValid, true);
+        // Detecta padrão fraco "password"
+        expect(result.value!.strength, lessThan(50));
+      });
+
+      test('calcula força alta para senha fortes com variação', () {
+        final result = PasswordValidator.validate(
+          'XyZ#Abc9@123',
+        );
+        expect(result.isValid, true);
+        expect(result.value!.strength, greaterThan(70));
+      });
+
+      test('calcula força média para senha média', () {
+        final result = PasswordValidator.validate('MyPassword123');
+        expect(result.isValid, true);
+        expect(result.value!.strength, inInclusiveRange(40, 80));
+      });
+    });
+
+    group('custom requirements', () {
+      test('valida com custom minLength', () {
+        const custom = PasswordRequirements(minLength: 5);
+        final result = PasswordValidator.validate('Ab123', custom);
+        expect(result.isValid, true);
+      });
+
+      test('valida com custom specialCharacters', () {
+        const custom = PasswordRequirements(
+          minLength: 8,
+          specialCharacters: '!@#',
+          requireSpecialCharacters: true,
+        );
+        final result = PasswordValidator.validate('MyPass!', custom);
+        // Falha por minLength = 8, tem apenas 7
+        expect(result.isInvalid, true);
+      });
+
+      test('valida com custom specialCharacters (suficiente comprimento)', () {
+        const custom = PasswordRequirements(
+          minLength: 8,
+          specialCharacters: '!@#',
+          requireSpecialCharacters: true,
+        );
+        // MyPassword1! tem uppercase, lowercase, numbers, e special char
+        final result = PasswordValidator.validate('MyPassword1!', custom);
+        expect(result.isValid, true);
+      });
+
+      test('pode desabilitar requisitos', () {
+        const custom = PasswordRequirements(
+          minLength: 6,
+          requireUppercase: false,
+          requireNumbers: false,
+        );
+        final result = PasswordValidator.validate('abcdef', custom);
+        expect(result.isValid, true);
+      });
+    });
+
+    group('error messages', () {
+      test('retorna lista de requisitos falhados', () {
+        final result = PasswordValidator.validate('short');
+        expect(result.isInvalid, true);
+        // Deve rejeitar por múltiplos motivos
+      });
+    });
+  });
+}

--- a/test/src/domain/validators/url_validator_test.dart
+++ b/test/src/domain/validators/url_validator_test.dart
@@ -1,0 +1,115 @@
+import 'package:ciot_dart/src/domain/validators/validators.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('UrlValidator', () {
+    group('validate', () {
+      test('valida URL HTTP', () {
+        final result = UrlValidator.validate('http://example.com');
+        expect(result.isValid, true);
+        expect(result.value?.scheme, 'http');
+        expect(result.value?.host, 'example.com');
+      });
+
+      test('valida URL HTTPS', () {
+        final result = UrlValidator.validate('https://example.com');
+        expect(result.isValid, true);
+      });
+
+      test('valida URL com www', () {
+        final result = UrlValidator.validate('http://www.example.com');
+        expect(result.isValid, true);
+      });
+
+      test('valida URL com path', () {
+        final result = UrlValidator.validate('http://example.com/path/to/page');
+        expect(result.isValid, true);
+      });
+
+      test('valida URL com query string', () {
+        final result = UrlValidator.validate('http://example.com?key=value');
+        expect(result.isValid, true);
+      });
+
+      test('valida URL com porta', () {
+        final result = UrlValidator.validate('http://example.com:8080');
+        expect(result.isValid, true);
+      });
+
+      test('valida URL localhost com porta', () {
+        final result = UrlValidator.validate('http://localhost:8080');
+        expect(result.isValid, true);
+      });
+
+      test('valida URL com IP', () {
+        final result = UrlValidator.validate('http://192.168.1.1');
+        expect(result.isValid, true);
+      });
+
+      test('rejeita URL sem schema quando requireScheme=false mas sem host', () {
+        // Uri.parse sem schema trata como caminho relativo, não como URL com host
+        final result = UrlValidator.validate('example.com', requireScheme: false);
+        expect(result.isInvalid, true);
+      });
+
+      test('valida URL com schema http implícito', () {
+        final result = UrlValidator.validate('http://example.com');
+        expect(result.isValid, true);
+      });
+
+      test('rejeita URL vazia', () {
+        final result = UrlValidator.validate('');
+        expect(result.error, ValidationError.emptyValue);
+      });
+
+      test('rejeita URL apenas espaços', () {
+        final result = UrlValidator.validate('   ');
+        expect(result.error, ValidationError.emptyValue);
+      });
+
+      test('rejeita URL com schema inválido', () {
+        final result = UrlValidator.validate('ftp://example.com', allowedSchemes: ['http', 'https']);
+        expect(result.isInvalid, true);
+      });
+
+      test('rejeita URL sem schema quando obrigatório', () {
+        final result = UrlValidator.validate('example.com', requireScheme: true);
+        expect(result.isInvalid, true);
+      });
+    });
+
+    group('validateHttpUrl', () {
+      test('valida URL HTTP', () {
+        final result = UrlValidator.validateHttpUrl('http://example.com');
+        expect(result.isValid, true);
+      });
+
+      test('valida URL HTTPS', () {
+        final result = UrlValidator.validateHttpUrl('https://example.com');
+        expect(result.isValid, true);
+      });
+
+      test('rejeita URL FTP', () {
+        final result = UrlValidator.validateHttpUrl('ftp://example.com');
+        expect(result.isInvalid, true);
+      });
+
+      test('rejeita URL sem schema', () {
+        final result = UrlValidator.validateHttpUrl('example.com');
+        expect(result.isInvalid, true);
+      });
+    });
+
+    group('validateUrlWithScheme', () {
+      test('valida URL com schema específico', () {
+        final result = UrlValidator.validateUrlWithScheme('ftp://example.com', 'ftp');
+        expect(result.isValid, true);
+      });
+
+      test('rejeita URL com schema diferente', () {
+        final result = UrlValidator.validateUrlWithScheme('http://example.com', 'ftp');
+        expect(result.isInvalid, true);
+      });
+    });
+  });
+}


### PR DESCRIPTION
This pull request introduces a new set of reusable validators for common input types (email, IP, password, and URL) to the domain layer. It includes robust validation logic, standardized error handling, and unified result types, making it easier to validate user input consistently throughout the codebase.

**New Validators and Validation Infrastructure:**

* Added a comprehensive email validator with support for domain restrictions and length checks in `email_validator.dart`.
* Implemented an IP address validator supporting IPv4, IPv6, and subnet mask validation in `ip_validator.dart`.
* Introduced a password validator with configurable requirements and strength estimation in `password_validator.dart`.
* Added a URL validator supporting scheme and host restrictions in `url_validator.dart`.

**Validation Error and Result Standardization:**

* Defined a unified `ValidationError` enum with human-readable descriptions for all supported validation failures in `validation_error.dart`.
* Introduced the `ValidationResult` type alias (using `Either`) and extension helpers for ergonomic result handling in `validation_result.dart`.
* Added a base `Validator` function type for consistent validator signatures in `validator.dart`.

**Exports and Integration:**

* Created a `validators.dart` barrel file to export all validators and related types, and re-exported it from the domain layer for easy access. [[1]](diffhunk://#diff-28a43c1fe1d6eb244345cdb510ccfa778ff66c8614eba1554ddd1cf69bfb5271R1-R7) [[2]](diffhunk://#diff-c4dea886147b3bd255334be56d415357132275f0071403234ee3151a319f31feR21)