### PR TITLE
Feat/mqtt client

### DIFF
--- a/lib/src/domain/interfaces/message_bus.dart
+++ b/lib/src/domain/interfaces/message_bus.dart
@@ -8,6 +8,9 @@ class MessageEvent<T> {
 }
 
 abstract class MessageBus<T> {
+  /// Emits `true` when connected to the broker and `false` when disconnected.
+  Stream<bool> get onConnectionState;
+
   /// Starts listening to the given [topic] and returns a stream of
   /// [MessageEvent]s where each event includes the original topic and the
   /// decoded payload.

--- a/lib/src/infra/interfaces/message_bus_mqtt.dart
+++ b/lib/src/infra/interfaces/message_bus_mqtt.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:developer';
 import 'dart:typed_data';
 
+import 'package:ciot_dart/generated/ciot/proto/v2/event.pb.dart';
 import 'package:ciot_dart/src/domain/domain.dart';
 import 'package:ciot_dart/src/infra/interfaces/mqtt_client.dart' as ciot;
 import 'package:ciot_dart/src/infra/interfaces/serializer_pb.dart';
@@ -11,11 +12,31 @@ class MessageBusMqtt<T> implements MessageBus<T> {
   final Map<String, StreamController<MessageEvent<T>>> _controllers = {};
   final Serializer _serializer;
   StreamSubscription? _updatesSub;
+  StreamSubscription? _connectionSub;
   Stream<ciot.MqttClientEvent>? _clientBroadcast;
 
-  MessageBusMqtt(this._client) : _serializer = SerializerPb.instance;
+  final StreamController<bool> _connectionStateController = StreamController<bool>.broadcast();
 
-  MessageBusMqtt.withSerializer(this._client, this._serializer);
+  MessageBusMqtt(this._client) : _serializer = SerializerPb.instance {
+    _listenToConnectionState();
+  }
+
+  MessageBusMqtt.withSerializer(this._client, this._serializer) {
+    _listenToConnectionState();
+  }
+
+  void _listenToConnectionState() {
+    _connectionSub = _client.onEvent.listen((event) {
+      if (event.type == EventType.EVENT_TYPE_STARTED) {
+        _connectionStateController.add(true);
+      } else if (event.type == EventType.EVENT_TYPE_STOPPED) {
+        _connectionStateController.add(false);
+      }
+    });
+  }
+
+  @override
+  Stream<bool> get onConnectionState => _connectionStateController.stream;
 
   @override
   Stream<MessageEvent<T>> startListening(String topic) {
@@ -87,5 +108,11 @@ class MessageBusMqtt<T> implements MessageBus<T> {
       await _updatesSub?.cancel();
       _updatesSub = null;
     }
+  }
+
+  Future<void> dispose() async {
+    await _connectionSub?.cancel();
+    await _connectionStateController.close();
+    _cleanupAll();
   }
 }

--- a/lib/src/infra/interfaces/mqtt_client.dart
+++ b/lib/src/infra/interfaces/mqtt_client.dart
@@ -60,8 +60,10 @@ class MqttClient extends IfaceBase {
 
   void init(mqtt.MqttClient client) {
     _client = client;
+    _client!.keepAlivePeriod = 10;
     _client!.onConnected = _onConnected;
     _client!.onDisconnected = _onDisconnected;
+    _client!.onAutoReconnect = _onDisconnected;
     _cfg = MqttClientCfg(
       url: client.server,
       clientId: client.clientIdentifier,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ciot_dart
 description: "A new Flutter package project."
-version: 1.1.0+11
+version: 1.2.0+12
 publish_to: none
 
 environment:


### PR DESCRIPTION
This pull request introduces enhancements to the MQTT message bus infrastructure, focusing on connection state tracking and resource management, as well as minor improvements to the MQTT client configuration. The changes add a new stream for observing connection status, ensure proper cleanup of resources, and update the MQTT client keep-alive behavior.

**Connection State Tracking:**

* Added an `onConnectionState` stream to the `MessageBus` interface, allowing consumers to listen for connection and disconnection events. (`lib/src/domain/interfaces/message_bus.dart`)
* Implemented the `onConnectionState` stream in `MessageBusMqtt`, with logic to emit `true` when connected and `false` when disconnected, based on broker events. (`lib/src/infra/interfaces/message_bus_mqtt.dart`)

**Resource Management:**

* Added a `dispose` method to `MessageBusMqtt` to clean up connection subscriptions and close the connection state stream controller. (`lib/src/infra/interfaces/message_bus_mqtt.dart`)

**MQTT Client Improvements:**

* Set the MQTT client's `keepAlivePeriod` to 10 seconds and assigned the `onAutoReconnect` callback to reuse the `onDisconnected` logic, improving connection reliability. (`lib/src/infra/interfaces/mqtt_client.dart`)

**Dependency Updates:**

* Bumped the package version to `1.2.0+12` in `pubspec.yaml`. (`pubspec.yaml`)